### PR TITLE
warning free on reframe version 4.0.4

### DIFF
--- a/tests/affinity/affinity_check.py
+++ b/tests/affinity/affinity_check.py
@@ -4,6 +4,7 @@ import reframe.utility.sanity as sn
 # Test process/thread affinity. Based on test from CSCS.
 
 class AffinityTestBase(rfm.RegressionTest):
+    
     def __init__(self, variant):
         self.valid_systems = ['archer2:compute']
         self.valid_prog_environs = ['*']
@@ -35,10 +36,13 @@ class AffinityTestBase(rfm.RegressionTest):
         ])
 
 
-@rfm.parameterized_test(['omp_bind_threads'])
+@rfm.simple_test
 class AffinityOMPTest(AffinityTestBase):
-    def __init__(self, variant):
-        super().__init__(variant)
+    
+    variant = parameter(['omp_bind_threads'])
+    
+    def __init__(self):
+        super().__init__(self.variant)
         self.descr = 'Checking core affinity for OMP threads.'
         self.cases = {
             'omp_bind_threads': {
@@ -50,31 +54,29 @@ class AffinityOMPTest(AffinityTestBase):
                 'OMP_PLACES': 'cores',
             },
         }
-        self.variant = variant
-        self.num_tasks = self.cases[variant]['num_tasks']
-        self.num_tasks_per_node = self.cases[variant]['num_tasks_per_node']
-        self.num_cpus_per_task = self.cases[variant]['num_cpus_per_task']
-        self.extra_resources = {
-                'qos': {'qos': 'standard'}
-        }
+        self.num_tasks = self.cases[self.variant]['num_tasks']
+        self.num_tasks_per_node = self.cases[self.variant]['num_tasks_per_node']
+        self.num_cpus_per_task = self.cases[self.variant]['num_cpus_per_task']
+        self.extra_resources = {'qos': {'qos': 'standard'}}
 
     @run_before('run')
     def set_tasks_per_core(self):
         partname = self.current_partition.fullname
         self.num_cpus_per_task = self.cases[self.variant]['num_cpus_per_task_%s' % partname]
         self.num_tasks = 1
-        self.variables  = {
+        self.env_vars = {
             'OMP_NUM_THREADS': str(self.num_cpus_per_task),
             'OMP_PLACES': self.cases[self.variant]['OMP_PLACES']
         }
 
 
-@rfm.parameterized_test(['fully_populated_nosmt'],
-                        ['fully_populated_smt'],
-                        ['single_process_per_numa'])
+@rfm.simple_test
 class AffinityMPITest(AffinityTestBase):
-    def __init__(self, variant):
-        super().__init__(variant)
+
+    variant = parameter(['fully_populated_nosmt','fully_populated_smt','single_process_per_numa'])
+
+    def __init__(self):
+        super().__init__(self.variant)
         self.descr = 'Checking core affinity for MPI processes.'
         self.valid_systems = ['archer2:compute']
         self.cases = {
@@ -100,10 +102,10 @@ class AffinityMPITest(AffinityTestBase):
                 'num_cpus_per_task': 16,
             },
         }
-        self.variant = variant
-        self.num_tasks = self.cases[variant]['num_tasks']
-        self.num_tasks_per_node = self.cases[variant]['num_tasks_per_node']
-        self.num_cpus_per_task = self.cases[variant]['num_cpus_per_task']
+        self.num_tasks = self.cases[self.variant]['num_tasks']
+        self.num_tasks_per_node = self.cases[self.variant]['num_tasks_per_node']
+        self.num_cpus_per_task = self.cases[self.variant]['num_cpus_per_task']
+        self.extra_resources = {'qos': {'qos': 'standard'}}
 
     @run_before('run')
     def set_launcher(self):

--- a/tests/apps/castep/castep_check.py
+++ b/tests/apps/castep/castep_check.py
@@ -46,7 +46,6 @@ class CASTEPCPUCheck(CASTEPBaseCheck):
 
         self.valid_systems = ['archer2:compute']
         self.descr = 'CASTEP corrctness and performance test'
-        self.name = 'castep_cpu_check'
         self.executable_opts = ['al3x3']
 
         if (self.current_system.name in ['archer2']):
@@ -55,7 +54,7 @@ class CASTEPCPUCheck(CASTEPBaseCheck):
            self.num_tasks_per_node = 128
            self.num_cpus_per_task = 1
            self.time_limit = '20m'
-        self.variables = {
+        self.env_vars= {
             'OMP_NUM_THREADS': str(self.num_cpus_per_task)
         }
 

--- a/tests/apps/cp2k/cp2k_check.py
+++ b/tests/apps/cp2k/cp2k_check.py
@@ -46,7 +46,6 @@ class CP2KCPUCheck(CP2KBaseCheck):
 
         self.valid_systems = ['archer2:compute']
         self.descr = 'CP2K check'
-        self.name = 'cp2k_cpu_check'
         self.executable_opts = ('-i input_bulk_HFX_3.inp -o cp2k.out ').split()
 
         if (self.current_system.name in ['archer2']):
@@ -55,7 +54,7 @@ class CP2KCPUCheck(CP2KBaseCheck):
            self.num_tasks_per_node = 16
            self.num_cpus_per_task = 8
            self.time_limit = '1h'
-        self.variables = {
+        self.env_vars = {
             'OMP_NUM_THREADS': str(self.num_cpus_per_task),
             'OMP_PLACES': 'cores'
         }
@@ -65,7 +64,7 @@ class CP2KCPUCheck(CP2KBaseCheck):
                 }
             }
         
-    @rfm.run_before('run')
+    @run_before('run')
     def set_task_distribution(self):
         self.job.options = ['--distribution=block:block']
 

--- a/tests/apps/gromacs/gromacs_check.py
+++ b/tests/apps/gromacs/gromacs_check.py
@@ -46,7 +46,6 @@ class GromacsCPUCheck(GromacsBaseCheck):
 
         self.valid_systems = ['archer2:compute']
         self.descr = 'GROMACS check'
-        self.name = 'gromacs_cpu_check'
         self.executable_opts = ('mdrun -noconfout -s gmx_1400k_atoms.tpr ').split()
 
         if (self.current_system.name in ['archer2']):
@@ -55,7 +54,7 @@ class GromacsCPUCheck(GromacsBaseCheck):
            self.num_tasks_per_node = 128
            self.num_cpus_per_task = 1
            self.time_limit = '1h'
-        self.variables = {
+        self.env_vars = {
             'OMP_NUM_THREADS': str(self.num_cpus_per_task)
         }
 

--- a/tests/apps/lammps/dipole_large.py
+++ b/tests/apps/lammps/dipole_large.py
@@ -43,7 +43,6 @@ class LAMMPSARCHER2LargeCheck(LAMMPSBaseCheck):
 
         self.valid_systems = ['archer2:compute']
         self.descr = 'LAMMPS large scale performance test'
-        self.name = 'LAMMPS_1024node_ARCHER2_test'
         self.executable_opts = ['in_2048.dipole']
 
         self.modules = ['lammps']
@@ -51,7 +50,7 @@ class LAMMPSARCHER2LargeCheck(LAMMPSBaseCheck):
         self.num_tasks_per_node = 128
         self.num_cpus_per_task = 1
         self.time_limit = '20m'
-        self.variables = {
+        self.env_vars = {
             'OMP_NUM_THREADS': str(self.num_cpus_per_task)
         }
 

--- a/tests/compile/hello/hello.py
+++ b/tests/compile/hello/hello.py
@@ -1,13 +1,15 @@
 import reframe.utility.sanity as sn
 import reframe as rfm
 
-
-@rfm.parameterized_test(['c'],['cpp'],['f90'])
+@rfm.simple_test
 class HelloTest(rfm.RegressionTest):
-    def __init__(self, lang):
+    
+    lang=parameter(['c','cpp','f90'])
+    
+    def __init__(self):
         self.valid_systems = ['*']
         self.valid_prog_environs = ['*']
-        self.sourcepath = f'hello.{lang}'
+        self.sourcepath = f'hello.{self.lang}'
         self.sanity_patterns = sn.assert_found(r'Hello, World\!', self.stdout)
         self.extra_resources = {
                 'qos': {'qos': 'standard'}

--- a/tests/compile/hello/src/hello.c
+++ b/tests/compile/hello/src/hello.c
@@ -3,7 +3,7 @@
 
 int main()
 {
-    printf("Hello, World!\n");
+    printf("Hello, World! from C\n");
     return 0;
 }
 

--- a/tests/compile/hello/src/hello.cpp
+++ b/tests/compile/hello/src/hello.cpp
@@ -3,7 +3,7 @@
 
 int main()
 {
-    std::cout << "Hello, World!\n";
+    std::cout << "Hello, World! from C++\n";
     return 0;
 }
 

--- a/tests/compile/hello/src/hello.f90
+++ b/tests/compile/hello/src/hello.f90
@@ -1,4 +1,4 @@
 program hello
    implicit none
-   write(6,*) "Hello, World!"
+   write(6,*) "Hello, World! from fortran"
 end program hello

--- a/tests/env/module_check.py
+++ b/tests/env/module_check.py
@@ -37,6 +37,6 @@ class EnvironmentCheck(rfm.RunOnlyRegressionTest):
         self.tags = {'production', 'craype'}
 
     @property
-    @sn.sanity_function
+    @deferrable
     def env_module_patt(self):
         return r'^%s' % self.current_environ.name

--- a/tests/known-issues/gcc-mpi_f08/gcc-mpi_f08.py
+++ b/tests/known-issues/gcc-mpi_f08/gcc-mpi_f08.py
@@ -9,12 +9,15 @@ import reframe as rfm
 # This issue prevents the mpi_f08 interface being used. We expect GCC to potentially
 # be affected and other compilers to not be affected.
 
-@rfm.parameterized_test(['f90'])
+@rfm.simple_test
 class InterfaceBoundsTest(rfm.RegressionTest):
-    def __init__(self, lang):
+    
+    lang = parameter(['f90'])
+
+    def __init__(self):
         self.valid_systems = ['archer2:login']
         self.valid_prog_environs = ['*']
-        self.sourcepath = f'gcc-mpi_f08.{lang}'
+        self.sourcepath = f'gcc-mpi_f08.{self.lang}'
         self.sanity_patterns = sn.assert_not_found(r'F', self.stdout)
         self.tags = {'functionality','short','issues'}
         self.maintainers = ['a.turner@epcc.ed.ac.uk']

--- a/tests/libs/blas/blas.py
+++ b/tests/libs/blas/blas.py
@@ -1,21 +1,23 @@
 import reframe as rfm
 import reframe.utility.sanity as sn
 
-@rfm.parameterized_test(['libsci'],['mkl'])
+@rfm.simple_test
 class BlasTest(rfm.RegressionTest):
-    def __init__(self, libname):
+    variant = parameter(['libsci', 'mkl'])
+    
+    def __init__(self):
         self.valid_systems = ['archer2']
         self.valid_prog_environs = ['PrgEnv-gnu','PrgEnv-aocc']
 
-        if libname == 'mkl':
+        if self.variant == 'mkl':
             self.modules = ['mkl']
             self.prebuild_cmds = ['module load mkl']
         else:
             self.prebuild_cmds = []
         self.build_system = 'Make'
-        self.build_system.makefile = f'Makefile.{libname}'
+        self.build_system.makefile = f'Makefile.{self.variant}'
 
-        self.executable = f'./dgemv_{libname}.x'
+        self.executable = f'./dgemv_{self.variant}.x'
         self.executable_opts = ['3200','150','10000']
 
         self.sanity_patterns = sn.assert_found(r'Normal',

--- a/tests/synth/mpi_osu/osu_benchmarks.py
+++ b/tests/synth/mpi_osu/osu_benchmarks.py
@@ -13,15 +13,13 @@ import reframe.utility.udeps as udeps
 class OSUBenchmarkTestBase(rfm.RunOnlyRegressionTest):
     '''Base class of OSU benchmarks runtime tests'''
 
-    valid_systems = ['archer2:compute']
-    valid_prog_environs = ['PrgEnv-gnu', 'PrgEnv-cray', 'PrgEnv-aocc']
-    sourcesdir = None
-    num_tasks = 2
-    num_tasks_per_node = 1
-
-    self.extra_resources = {
-        'qos': {'qos': 'standard'}
-    }
+    def __init__(self):
+        self.valid_systems = ['archer2:compute']
+        self.valid_prog_environs = ['PrgEnv-gnu', 'PrgEnv-cray', 'PrgEnv-aocc']
+        self.sourcesdir = None
+        self.num_tasks = 2
+        self.num_tasks_per_node = 1
+        self.extra_resources = {'qos': {'qos': 'standard'}}
 
     @run_after('init')
     def set_dependencies(self):
@@ -34,7 +32,10 @@ class OSUBenchmarkTestBase(rfm.RunOnlyRegressionTest):
 
 @rfm.simple_test
 class OSULatencyTest(OSUBenchmarkTestBase):
-    descr = 'OSU latency test'
+    
+    def __init__(self):
+        super().__init__()
+        self.descr = 'OSU latency test'
 
     @require_deps
     def set_executable(self, OSUBuildTest):
@@ -51,7 +52,10 @@ class OSULatencyTest(OSUBenchmarkTestBase):
 
 @rfm.simple_test
 class OSUBandwidthTest(OSUBenchmarkTestBase):
-    descr = 'OSU bandwidth test'
+
+    def __init__(self):
+        super().__init__()
+        self.descr = 'OSU bandwidth test'
 
     @require_deps
     def set_executable(self, OSUBuildTest):
@@ -69,8 +73,12 @@ class OSUBandwidthTest(OSUBenchmarkTestBase):
 
 @rfm.simple_test
 class OSUAllreduceTest(OSUBenchmarkTestBase):
+    
     mpi_tasks = parameter(1 << i for i in range(1, 5))
-    descr = 'OSU Allreduce test'
+
+    def __init__(self):
+        super().__init__()
+        self.descr = 'OSU Allreduce test'
 
     @run_after('init')
     def set_num_tasks(self):
@@ -91,10 +99,12 @@ class OSUAllreduceTest(OSUBenchmarkTestBase):
 
 @rfm.simple_test
 class OSUBuildTest(rfm.CompileOnlyRegressionTest):
-    descr = 'OSU benchmarks build test (currently fails with  Cray)'
-    valid_systems = ['archer2:compute']
-    valid_prog_environs = ['PrgEnv-gnu', 'PrgEnv-cray', 'PrgEnv-aocc']
-    build_system = 'Autotools'
+
+    def __init__(self):
+        self.descr = 'OSU benchmarks build test (currently fails with  Cray)'
+        self.valid_systems = ['archer2:compute']
+        self.valid_prog_environs = ['PrgEnv-gnu', 'PrgEnv-cray', 'PrgEnv-aocc']
+        self.build_system = 'Autotools'
 
     @run_after('init')
     def inject_dependencies(self):
@@ -118,16 +128,18 @@ class OSUBuildTest(rfm.CompileOnlyRegressionTest):
 
 @rfm.simple_test
 class OSUDownloadTest(rfm.RunOnlyRegressionTest):
-    descr = 'OSU benchmarks download sources'
-    valid_systems = ['archer2:login']
-    valid_prog_environs = ['PrgEnv-gnu', 'PrgEnv-cray', 'PrgEnv-aocc']
-    executable = 'wget'
-    executable_opts = [
-        'http://mvapich.cse.ohio-state.edu/download/mvapich/osu-micro-benchmarks-5.6.2.tar.gz'  # noqa: E501
-    ]
-    postrun_cmds = [
-        'tar xzf osu-micro-benchmarks-5.6.2.tar.gz'
-    ]
+    
+    def __init__(self):
+        self.descr = 'OSU benchmarks download sources'
+        self.valid_systems = ['archer2:login']
+        self.valid_prog_environs = ['PrgEnv-gnu', 'PrgEnv-cray', 'PrgEnv-aocc']
+        self.executable = 'wget'
+        self.executable_opts = [
+            'http://mvapich.cse.ohio-state.edu/download/mvapich/osu-micro-benchmarks-5.6.2.tar.gz'  # noqa: E501
+            ]
+        self.postrun_cmds = [
+            'tar xzf osu-micro-benchmarks-5.6.2.tar.gz'
+            ]
 
     @sanity_function
     def validate_download(self):

--- a/tests/utils/xthi/hetjob.py
+++ b/tests/utils/xthi/hetjob.py
@@ -2,7 +2,7 @@
 
 import os
 
-import reframe
+import reframe as rfm
 import reframe.utility.sanity as sanity
 import reframe.utility.udeps as depends
 
@@ -17,70 +17,68 @@ These are really by way of smoke tests, as there's no attempt to
 check the resulting placement at the moment.
 """
 
-@reframe.simple_test
-class SharedCommWorldTest(reframe.RunOnlyRegressionTest):
+@rfm.simple_test
+class SharedCommWorldTest(rfm.RunOnlyRegressionTest):
 
     """
     SLURM hetjob with 3 nodes (no OpenMP) as per frist example
     https://docs.archer2.ac.uk/user-guide/scheduler/#heterogeneous-jobs
     """
-
-    descr = "SLURM hetjob for xthi shared MPI_COM_WORLD"
-    valid_systems = ["archer2:compute"]
-    valid_prog_environs = ["*"]
-    modules = ["xthi"]
-
-    # Utter, utter kludge
-    # 1 + 2 nodes; 8 + 2x4 MPI tasks
-    hetgroup0 = "--het-group=0 --nodes=1 --ntasks=8 --ntasks-per-node=8 xthi"
-    hetgroup1 = "--het-group=1 --nodes=2 --ntasks=8 --ntasks-per-node=4 xthi"
-    executable = hetgroup0 + " : " + hetgroup1
-
-    time_limit ="2m"
-    # Kludge three nodes because we can't set the number of nodes explicitly
-    num_tasks = 3
-    num_tasks_per_node = 1
-    variables = {"OMP_PLACES": "cores"}
-
-    self.extra_resources = {
-         'qos': {'qos': 'standard'}
-    }
+    def __init__(self):
+        self.descr = "SLURM hetjob for xthi shared MPI_COM_WORLD"
+        self.valid_systems = ["archer2:compute"]
+        self.valid_prog_environs = ["*"]
+        self.modules = ["xthi"]
+        
+        # Utter, utter kludge
+        # 1 + 2 nodes; 8 + 2x4 MPI tasks
+        self.hetgroup0 = "--het-group=0 --nodes=1 --ntasks=8 --ntasks-per-node=8 xthi"
+        self.hetgroup1 = "--het-group=1 --nodes=2 --ntasks=8 --ntasks-per-node=4 xthi"
+        self.executable = self.hetgroup0 + " : " + self.hetgroup1
+        
+        self.time_limit ="2m"
+        # Kludge three nodes because we can't set the number of nodes explicitly
+        self.num_tasks = 3
+        self.num_tasks_per_node = 1
+        self.env_vars = {"OMP_PLACES": "cores"}
+        self.extra_resources = {'qos': {'qos': 'standard'}}
 
     @sanity_function
     def sanity_check_run(self):
-
+     
         return sanity.assert_found("Node summary", self.stdout)
 
 
-@reframe.simple_test
-class SharedCommWorldWithOpenMPTest(reframe.RunOnlyRegressionTest):
+@rfm.simple_test
+class SharedCommWorldWithOpenMPTest(rfm.RunOnlyRegressionTest):
 
     """
     SLURM hetjob with shared MPI_COMM_WORLD and OpenMP as per
     the mixed MPI/OpenMP example at
     https://docs.archer2.ac.uk/user-guide/scheduler/#heterogeneous-jobs
     """
-
-    descr = "SLURM hetjob for shared MPI_COM_WORLD with OpenMP"
-    valid_systems = ["archer2:compute"]
-    valid_prog_environs = ["*"]
-    modules = ["xthi"]
-
-    # Two nodes with 8 MPI tasks per node
-    shared_args = " --nodes=1 --ntasks=8 --tasks-per-node=8 --cpus-per-task=16"
-    openmp0     = " --export=all,OMP_NUM_THREADS=16"
-    openmp1     = " --export=all,OMP_NUM_THREADS=1"
-    hetgroup0   = "--het-group=0" + shared_args + openmp0 + " xthi"
-    hetgroup1   = "--het-group=1" + shared_args + openmp1 + " xthi"
-    executable  = hetgroup0 + " : " + hetgroup1
-
-    time_limit ="2m"
-
-    # Kludge two nodes because we can't set the number of nodes explicitly
-    num_tasks = 2
-    num_tasks_per_node = 1
-
-    variables = {"OMP_PLACES": "cores"}
+    def __init__(self):
+        self.descr = "SLURM hetjob for shared MPI_COM_WORLD with OpenMP"
+        self.valid_systems = ["archer2:compute"]
+        self.valid_prog_environs = ["*"]
+        self.modules = ["xthi"]
+        
+        # Two nodes with 8 MPI tasks per node
+        self.shared_args = " --nodes=1 --ntasks=8 --tasks-per-node=8 --cpus-per-task=16"
+        self.openmp0     = " --export=all,OMP_NUM_THREADS=16"
+        self.openmp1     = " --export=all,OMP_NUM_THREADS=1"
+        self.hetgroup0   = "--het-group=0" + self.shared_args + self.openmp0 + " xthi"
+        self.hetgroup1   = "--het-group=1" + self.shared_args + self.openmp1 + " xthi"
+        self.executable  = self.hetgroup0 + " : " + self.hetgroup1
+        
+        self.time_limit ="2m"
+        
+        # Kludge two nodes because we can't set the number of nodes explicitly
+        self.num_tasks = 2
+        self.num_tasks_per_node = 1
+        
+        self.env_vars = {"OMP_PLACES": "cores"}
+        self.extra_resources = {'qos': {'qos': 'standard'}}
 
     @run_before("run")
     def unset_omp_num_threads(self):


### PR DESCRIPTION
Updates to existing config to remove warnings and errors due to functionality deprecation from reframe version 3.8.2 to version 4.0.4.

Please test to confirm changes are correct. 