### PR TITLE
Fixing delete for serial test case so all files get deleted

### DIFF
--- a/tests/synth/benchio/src/src/benchio.f90
+++ b/tests/synth/benchio/src/src/benchio.f90
@@ -27,7 +27,7 @@ program benchio
   character*(maxlen), dimension(numstriping) :: stripestring
   character*(maxlen) :: argstring
 
-  logical :: ioflag, stripeflag, globalflag
+  logical :: ioflag, stripeflag, globalflag, serialio
   logical, dimension(numiolayer)  :: doio
   logical, dimension(numstriping) :: dostripe
 
@@ -56,6 +56,7 @@ program benchio
 
   logical :: reorder = .false.
   logical, dimension(ndim) :: periods = [.false., .false., .false.]
+  
 
   double precision :: t0, t1, time, iorate, gibdata
 
@@ -294,7 +295,7 @@ program benchio
   do iolayer = 1, numiolayer
 
      if (.not. doio(iolayer)) cycle
-
+     
      if (rank == 0) then
         write(*,*)
         write(*,*) "------"
@@ -316,6 +317,8 @@ program benchio
      do istriping = 1, numstriping
 
         if (.not. dostripe(istriping)) cycle
+
+        serialio = .false.
 
         filename = trim(stripestring(istriping))//"/"//trim(iolayername(iolayer))
         suffix = ""
@@ -348,6 +351,7 @@ program benchio
 
         case(1:3)
            call serialwrite(filename, iodata, n1, n2, n3, iocomm)
+           serialio = .true.
 
         case(4)
            call mpiiowrite(filename, iodata, n1, n2, n3, iocomm)
@@ -395,7 +399,7 @@ program benchio
           call MPI_Barrier(comm, ierr)
         
         else
-           call bossdelete(filename, iocomm)
+           call bossdelete(filename, iocomm, serialio)
         endif
         
      end do

--- a/tests/synth/benchio/src/src/benchutil.f90
+++ b/tests/synth/benchio/src/src/benchutil.f90
@@ -96,7 +96,7 @@ contains
 
   end subroutine initbenchnode
 
-  subroutine bossdelete(filename, comm)
+  subroutine bossdelete(filename, comm, serialio)
 
     use mpi
 
@@ -104,13 +104,14 @@ contains
 
     character *(*) :: filename
     integer :: comm
-    
+    logical :: serialio    
+
     integer, parameter :: iounit = 15
     integer :: rank, ierr, stat
 
     call MPI_Comm_rank(comm, rank, ierr)
 
-    if (rank == 0) then
+    if (serialio .or. rank == 0) then
 
        open(unit=iounit, iostat=stat, file=filename, status='old')
        if (stat.eq.0) close(unit=iounit, status='delete')


### PR DESCRIPTION
Fixing a small implementation issue where the serial test cases (file per process) only currently delete the "boss" file.