### PR TITLE
Add IO500 synth test for ARCHER2

### DIFF
--- a/tests/synth/io500/io500.py
+++ b/tests/synth/io500/io500.py
@@ -117,6 +117,8 @@ class IO500RunDebug(IO500Benchmark):
 @rfm.simple_test
 class IO500RunValid(IO500Benchmark):
     '''Run a large scale IO500 test.'''
+    fs = parameter(['work4'])
+
     def __init__(self):
         super().__init__()
         self.num_tasks = 80

--- a/tests/synth/io500/io500.py
+++ b/tests/synth/io500/io500.py
@@ -1,10 +1,64 @@
 import reframe as rfm
 import reframe.utility.sanity as sn
 import reframe.utility.udeps as udeps
-import reframe.utility.osext as osext
+from reframe.core.backends import getlauncher
 import os
 
 # IO500 I/O benchmark - https://io500.org/
+
+# TODO
+# This won't run -- there's likely no clean way to get the benchmark
+# test to run in the benchmark staging directory, while the executables
+# live in the build staging directory, as io500.sh relies on $PWD in the
+# 'YOU SHOULD NOT EDIT' portion.
+# Path forward is to either combine the build and benchmark tests, so
+# the run takes place automatically in the same staging directory, or
+# to manipulate the benchmark test to use the same staging directory
+# as the build test.
+
+@rfm.simple_test
+class IO500Benchmark(rfm.RunOnlyRegressionTest):
+    '''Run the IO500 benchmark.'''
+
+    def __init__(self):
+        self.descr = 'Run the IO500 benchmark.'
+        self.valid_systems = ['archer2:compute']
+        self.valid_prog_environs = ['PrgEnv-gnu']
+        self.sourcesdir = 'src'
+        self.num_tasks = 80
+        self.num_tasks_per_node = 8
+        # For now just run the debug ini.
+        self.config_file = "config-debug-run.ini"
+        self.executable_opts = [self.config_file]
+
+    @run_after('init')
+    def set_dependencies(self):
+        self.depends_on('IO500BuildTest', udeps.by_env)
+
+    # Set the location of the io500.sh script and fix it for our use.
+    # Ideally, I would like the ReFrame job to contain all of the fixed io500.sh
+    # in place of the srun launch, but at the moment I can't see how to do that.
+    @require_deps
+    def set_executable(self, IO500BuildTest):
+        stagedir = IO500BuildTest().stagedir
+        self.executable = os.path.join(stagedir, 'io500.sh')
+        # Delete everything *before* the warning in io500.sh, then prepend
+        # what remains with the contents of io500-prologue.sh which create
+        # the work directories and set their striping.
+        self.prerun_cmds = ["sed -i -n -E -e '/YOU SHOULD NOT EDIT/,$ p' " + self.executable,
+                            "cat io500-prologue.sh " + self.executable + " > io500-fixed.sh",
+                            "cp io500-fixed.sh " + self.executable]
+
+    # Override the job launch. We don't want to run srun within the job script.
+    # Instead just run io500.sh which will do the parallel launch internally.
+    @run_after('setup')
+    def set_launcher(self):
+        self.job.launcher = getlauncher('local')()
+
+    # Consider the test successful if 'Bandwidth' is found in output.
+    @sanity_function
+    def assert_io500(self):
+        return sn.assert_found(r'Bandwidth', self.stdout)
 
 @rfm.simple_test
 class IO500BuildTest(rfm.CompileOnlyRegressionTest):
@@ -13,7 +67,7 @@ class IO500BuildTest(rfm.CompileOnlyRegressionTest):
     def __init__(self):
         self.descr = 'Clone and build the IO500 benchmark.'
         self.lang = ['c']
-        self.valid_systems = ['archer2:login']
+        self.valid_systems = ['archer2:compute']
         self.valid_prog_environs = ['PrgEnv-gnu']
         self.build_system = 'CustomBuild'
         self.sourcesdir = 'https://github.com/IO500/io500.git'

--- a/tests/synth/io500/io500.py
+++ b/tests/synth/io500/io500.py
@@ -13,18 +13,21 @@ import os
 class IO500BuildTest(rfm.CompileOnlyRegressionTest):
     '''Clone and build the IO500 source code.'''
 
-    def __init__(self):
-        self.descr = 'Clone and build the IO500 benchmark.'
-        self.lang = ['c']
-        self.valid_systems = ['archer2:compute']
-        self.valid_prog_environs = ['PrgEnv-gnu']
-        self.build_system = 'CustomBuild'
-        self.sourcesdir = 'https://github.com/IO500/io500.git'
+    descr = 'Clone and build the IO500 benchmark.'
+    lang = ['c']
+    valid_systems = ['archer2:compute']
+    valid_prog_environs = ['PrgEnv-gnu']
+    build_system = 'CustomBuild'
+    sourcesdir = 'https://github.com/IO500/io500.git'
+
+    @run_before('compile')
+    def set_build_command(self):
         self.build_system.commands = ['./prepare.sh']
 
     @sanity_function
     def validate_build(self):
         return sn.assert_not_found('error', self.stderr)
+
 
 # Base class for the IO500 Benchmark runs.
 @rfm.simple_test

--- a/tests/synth/io500/io500.py
+++ b/tests/synth/io500/io500.py
@@ -25,8 +25,9 @@ class IO500Benchmark(rfm.RunOnlyRegressionTest):
         self.valid_systems = ['archer2:compute']
         self.valid_prog_environs = ['PrgEnv-gnu']
         self.sourcesdir = 'src'
-        self.num_tasks = 80
-        self.num_tasks_per_node = 8
+        self.num_tasks = 1
+        self.num_tasks_per_node = 1
+        self.time_limit = '10m'
         # For now just run the debug ini.
         self.config_file = "config-debug-run.ini"
         self.executable_opts = [self.config_file]
@@ -41,11 +42,13 @@ class IO500Benchmark(rfm.RunOnlyRegressionTest):
     @require_deps
     def set_executable(self, IO500BuildTest):
         stagedir = IO500BuildTest().stagedir
-        self.executable = os.path.join(stagedir, 'io500.sh')
+        # self.executable = os.path.join(stagedir, 'io500.sh')
+        self.executable = './io500.sh'
         # Delete everything *before* the warning in io500.sh, then prepend
         # what remains with the contents of io500-prologue.sh which create
         # the work directories and set their striping.
-        self.prerun_cmds = ["sed -i -n -E -e '/YOU SHOULD NOT EDIT/,$ p' " + self.executable,
+        self.prerun_cmds = ["cp -r " + stagedir + "/* .",
+                            "sed -i -n -E -e '/YOU SHOULD NOT EDIT/,$ p' " + self.executable,
                             "cat io500-prologue.sh " + self.executable + " > io500-fixed.sh",
                             "cp io500-fixed.sh " + self.executable]
 

--- a/tests/synth/io500/io500.py
+++ b/tests/synth/io500/io500.py
@@ -34,12 +34,11 @@ class IO500BuildTest(rfm.CompileOnlyRegressionTest):
 class IO500Benchmark(rfm.RunOnlyRegressionTest):
     '''Base IO500 benchmark class.'''
 
-    def __init__(self):
-        self.descr = 'Run the IO500 benchmark.'
-        self.valid_systems = ['archer2:compute']
-        self.valid_prog_environs = ['PrgEnv-gnu']
-        self.sourcesdir = 'src'
-        self.keep_files = ['results'] # retain the results directory
+    descr = 'Run the IO500 benchmark.'
+    valid_systems = ['archer2:compute']
+    valid_prog_environs = ['PrgEnv-gnu']
+    sourcesdir = 'src'
+    keep_files = ['results'] # retain the results directory
 
     @run_after('init')
     def set_dependencies(self):

--- a/tests/synth/io500/io500.py
+++ b/tests/synth/io500/io500.py
@@ -96,6 +96,7 @@ class IO500RunDebug(IO500Benchmark):
         self.executable_opts = ['config-debug-run.ini']
 
 # Test a large run that should be valid for submission to the IO500 list.
+# If the file system is under heavy load, this may take up to ~10 hours.
 @rfm.simple_test
 class IO500RunValid(IO500Benchmark):
     '''Run a large scale IO500 test.'''
@@ -103,5 +104,6 @@ class IO500RunValid(IO500Benchmark):
         super().__init__()
         self.num_tasks = 80
         self.num_tasks_per_node = 8
-        self.time_limit = '10m'
+        self.num_cpus_per_task = 16
+        self.time_limit = '10h'
         self.executable_opts = ['config-valid.ini']

--- a/tests/synth/io500/io500.py
+++ b/tests/synth/io500/io500.py
@@ -1,0 +1,24 @@
+import reframe as rfm
+import reframe.utility.sanity as sn
+import reframe.utility.udeps as udeps
+import reframe.utility.osext as osext
+import os
+
+# IO500 I/O benchmark - https://io500.org/
+
+@rfm.simple_test
+class IO500BuildTest(rfm.CompileOnlyRegressionTest):
+    '''Clone and build the IO500 source code.'''
+
+    def __init__(self):
+        self.descr = 'Clone and build the IO500 benchmark.'
+        self.lang = ['c']
+        self.valid_systems = ['archer2:login']
+        self.valid_prog_environs = ['PrgEnv-gnu']
+        self.build_system = 'CustomBuild'
+        self.sourcesdir = 'https://github.com/IO500/io500.git'
+        self.build_system.commands = ['./prepare.sh']
+
+    @sanity_function
+    def validate_build(self):
+        return sn.assert_not_found('error', self.stderr)

--- a/tests/synth/io500/src/config-debug-run.ini
+++ b/tests/synth/io500/src/config-debug-run.ini
@@ -1,0 +1,8 @@
+[global]
+datadir = ./datafiles
+timestamp-datadir = FALSE
+timestamp-resultdir = FALSE
+
+[debug]
+stonewall-time = 1
+pause-dir = ./pause/

--- a/tests/synth/io500/src/config-valid.ini
+++ b/tests/synth/io500/src/config-valid.ini
@@ -8,7 +8,7 @@ stonewall-time = 300
 nproc = 1
 
 [ior-hard]
-segmentCount = 50000 # must set value manual, otherwise runtime explodes
+segmentCount = 50000
 
 [mdtest-hard]
-n = 80000 # must set value manual, otherwise run into Lustre issue: "No space available on device"
+n = 80000

--- a/tests/synth/io500/src/config-valid.ini
+++ b/tests/synth/io500/src/config-valid.ini
@@ -1,0 +1,14 @@
+[global]
+datadir = ./datafiles
+
+[debug]
+stonewall-time = 300
+
+[find]
+nproc = 1
+
+[ior-hard]
+segmentCount = 50000 # must set value manual, otherwise runtime explodes
+
+[mdtest-hard]
+n = 80000 # must set value manual, otherwise run into Lustre issue: "No space available on device"

--- a/tests/synth/io500/src/io500-prologue.sh
+++ b/tests/synth/io500/src/io500-prologue.sh
@@ -1,11 +1,3 @@
-# INSTRUCTIONS:
-#
-# The only parts of the script that may need to be modified are:
-#  - setup() to configure the binary locations and MPI parameters
-# Please visit https://vi4io.org/io500-info-creator/ to help generate the
-# "system-information.txt" file, by pasting the output of the info-creator.
-# This file contains details of your system hardware for your submission.
-
 # This script takes its parameters from the same .ini file as io500 binary.
 io500_ini="$1"          # You can set the ini file here
 io500_mpirun="srun"

--- a/tests/synth/io500/src/io500-prologue.sh
+++ b/tests/synth/io500/src/io500-prologue.sh
@@ -1,0 +1,33 @@
+# INSTRUCTIONS:
+#
+# The only parts of the script that may need to be modified are:
+#  - setup() to configure the binary locations and MPI parameters
+# Please visit https://vi4io.org/io500-info-creator/ to help generate the
+# "system-information.txt" file, by pasting the output of the info-creator.
+# This file contains details of your system hardware for your submission.
+
+# This script takes its parameters from the same .ini file as io500 binary.
+io500_ini="$1"          # You can set the ini file here
+io500_mpirun="srun"
+io500_mpiargs="--hint=nomultithread --distribution=block:block"
+
+function setup(){
+  local workdir="$1"
+  local resultdir="$2"
+  mkdir -p $workdir $resultdir
+
+  lfs setstripe -c 1 $workdir
+  mkdir $workdir/ior-easy $workdir/ior-hard
+  mkdir $workdir/mdtest-easy $workdir/mdtest-hard
+  local osts=$(lfs df $workdir | grep -c OST)
+  # Try overstriping for ior-hard to improve scaling, or use wide striping
+  lfs setstripe -c $((osts * 4)) $workdir/ior-hard
+  # Try to use DoM if available, otherwise use default for small files
+  lfs setstripe -E 64k -L mdt $workdir/mdtest-easy || true #DoM?
+  lfs setstripe -E 64k -L mdt $workdir/mdtest-hard || true #DoM?
+
+  lfs getstripe $workdir/ior-easy
+  lfs getstripe $workdir/ior-hard
+  lfs getstripe $workdir/mdtest-easy
+  lfs getstripe $workdir/mdtest-hard
+}


### PR DESCRIPTION
This PR adds the IO500 benchmark in a configuration appropriate for ARCHER2. Tests are provided for debug runs and full 10-node valid runs, parametric across the four ARCHER2 file systems.

The IO500BuildTest class clones the IO500 repository and builds the benchmark.

The IO500Benchmark base class uses the previous test as a dependency. There are a couple of points to note:

- Valid IO500 tests should be run using the io500.sh script included with the source. Only the top portion which can include any settings appropriate for your system. The srun launch occurs within the uneditable portion. Normally, you might edit the top portion and then `sbatch io500.sh`. To work in ReFrame, I have the generated job script call `./io500.sh` directly.
- Separate `.ini` files are provided for the debug and valid tests. The location for the test directories is set in these and needs to be set before running.

These are both fixed at the beginning of the job itself. The top portion of io500.sh is removed, and a replacement which sets up striping for the data directories is prepended. Then the .ini file being used for the test is edited, replacing the original `datadir` parameter with the path to the data directories on the file system being benchmarked. The full test is copied from the IO500BuildTest stage directory, and the io500.sh prologue and `.ini` files come from the IO500Benchmark's `src` directory. As it seems staging for run-only tests only occurs at the start of the run phase, these fixes can't be made any earlier. If there are any better workarounds, I'd like to hear!

Finally, there are two classes IO500RunDebug and IO500RunValid which derive from IO500Benchmark and which provide the debug and valid tests for ARCHER2. The former should take only a few minutes to run, while I've seen the latter take up to 10 hours. There may well be room for tuning of the valid run's `.ini`. At the moment both tests are set to run only on `work4` but setting `fs = parameter(['work1', 'work2', 'work3', 'work4'])` would give parametric runs over all the work file systems.