### PR TITLE
Known-issue turn expected test fail into a pass in ReFrame

### DIFF
--- a/configuration/cirrus.py
+++ b/configuration/cirrus.py
@@ -37,7 +37,7 @@ site_configuration = {
                         "num_cpus": 36,
                         "num_cpus_per_socket": 18,
                         "num_sockets": 2,
-                    }
+                    },
                 },
                 {
                     "name": "highmem",
@@ -50,7 +50,7 @@ site_configuration = {
                         "--partition=highmem",
                     ],
                     "max_jobs": 16,
-                    "environs": ["gnu", "intel"],
+                    "environs": ["gcc", "intel"],
                     "resources": [
                         {
                             "name": "qos",
@@ -61,7 +61,7 @@ site_configuration = {
                         "num_cpus": 112,
                         "num_cpus_per_socket": 28,
                         "num_sockets": 4,
-                    }
+                    },
                 },
                 {
                     "name": "compute-gpu",
@@ -86,9 +86,7 @@ site_configuration = {
                         "num_cpus_per_socket": 20,
                         "num_sockets": 2,
                     },
-                    "devices": [
-                        {"type": "gpu", "num_devices": 4}
-                    ]
+                    "devices": [{"type": "gpu", "num_devices": 4}],
                 },
                 {
                     "name": "compute-gpu-default",
@@ -108,9 +106,7 @@ site_configuration = {
                         "num_cpus_per_socket": 20,
                         "num_sockets": 2,
                     },
-                    "devices": [
-                        {"type": "gpu", "num_devices": 4}
-                    ]
+                    "devices": [{"type": "gpu", "num_devices": 4}],
                 },
             ],
         }
@@ -144,6 +140,7 @@ site_configuration = {
         {
             "name": "Default",
             "cc": "gcc",
+            "ftn": "gfortran",
             "target_systems": ["cirrus"],
         },
     ],
@@ -169,10 +166,7 @@ site_configuration = {
                     "type": "file",
                     "name": "reframe.log",
                     "level": "debug",
-                    "format": (
-                        "[%(asctime)s] %(levelname)s "
-                        "%(levelno)s: %(check_info)s: %(message)s"
-                    ),
+                    "format": ("[%(asctime)s] %(levelname)s " "%(levelno)s: %(check_info)s: %(message)s"),
                     "append": False,
                 },
             ],

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,11 @@
+[project]
+name = "EPCC-Reframe"
+description = "ReFrame configuration and test suite for the EPCC HPC systems"
+dependencies = ["reframe-hpc"]
+requires-python = ">= 3.6"
+readme = "README.md"
+license = {file = "LICENSE"}
+
 [tool.black]
 line-length = 120
 

--- a/tests/known-issues/gcc_mpi_f08/gcc_mpi_f08.py
+++ b/tests/known-issues/gcc_mpi_f08/gcc_mpi_f08.py
@@ -9,6 +9,7 @@ https://gcc.gnu.org/pipermail/fortran/2020-September/055068.html
 
 This issue prevents the mpi_f08 interface being used.
 We expect GCC to potentially be affected and other compilers to not be affected.
+Errors will be reported if gcc passes the test, or another type of compiler fails the test.
 """
 
 import reframe as rfm
@@ -32,6 +33,10 @@ class InterfaceBoundsTest(rfm.RegressionTest):
         self.sourcepath = f"gcc_mpi_f08.{self.lang}"
 
     @sanity_function
-    def assert_notfound(self):
-        """Checks that issue was not found"""
+    def assert_result(self):
+        """Checks that issue was not found for non-gcc compilers"""
+        # Expect gcc to fail check
+        if str(self.current_environ) in ["PrgEnv-gnu", "gcc"]:
+            return sn.assert_found(r"F", self.stdout)
+        # Expect other compilers to pass check
         return sn.assert_not_found(r"F", self.stdout)

--- a/tests/known-issues/gcc_mpi_f08/gcc_mpi_f08.py
+++ b/tests/known-issues/gcc_mpi_f08/gcc_mpi_f08.py
@@ -36,7 +36,7 @@ class InterfaceBoundsTest(rfm.RegressionTest):
     def assert_result(self):
         """Checks that issue was not found for non-gcc compilers"""
         # Expect gcc to fail check
-        if str(self.current_environ) in ["PrgEnv-gnu", "gcc"]:
+        if self.current_environ.name in ["PrgEnv-gnu", "gcc"]:
             return sn.assert_found(r"F", self.stdout)
         # Expect other compilers to pass check
         return sn.assert_not_found(r"F", self.stdout)

--- a/tests/known-issues/gcc_mpi_f08/gcc_mpi_f08.py
+++ b/tests/known-issues/gcc_mpi_f08/gcc_mpi_f08.py
@@ -23,7 +23,7 @@ class InterfaceBoundsTest(rfm.RegressionTest):
     lang = parameter(["f90"])
 
     valid_systems = ["archer2:login", "cirrus:login"]
-    valid_prog_environs = ["*"]
+    valid_prog_environs = ["Default", "PrgEnv-cray", "PrgEnv-gnu", "gcc", "intel"]
     tags = {"functionality", "short", "issues"}
     maintainers = ["a.turner@epcc.ed.ac.uk"]
 

--- a/tests/known-issues/gcc_mpi_f08/src/gcc_mpi_f08.f90
+++ b/tests/known-issues/gcc_mpi_f08/src/gcc_mpi_f08.f90
@@ -1,43 +1,42 @@
-MODULE FOO
-INTERFACE
-SUBROUTINE dummyc(x0) BIND(C, name="sync")
-type(*), dimension(..) :: x0
-END SUBROUTINE
-END INTERFACE
-contains
-SUBROUTINE dummy(x0)
-type(*), dimension(..) :: x0
-call dummyc(x0)
-END SUBROUTINE
-END MODULE
+module foo
+  interface
+    subroutine dummyc(x0) bind(c, name="sync")
+      type(*), dimension(..) :: x0
+    end subroutine
+  end interface
+  contains
+    subroutine dummy(x0)
+      type(*), dimension(..) :: x0
+      call dummyc(x0)
+    end subroutine
+end module
 
-PROGRAM main
-    USE FOO
-    IMPLICIT NONE
+program main
+    use foo
+    implicit none
     integer :: before(2), after(2)
 
-    INTEGER, parameter :: n = 4
+    integer, parameter :: n = 4
 
-    DOUBLE PRECISION, ALLOCATABLE :: buf(:)
-    DOUBLE PRECISION :: buf2(n)
+    double precision, allocatable :: buf(:)
+    double precision :: buf2(n)
 
-    ALLOCATE(buf(n))
-    before(1) = LBOUND(buf,1)
-    before(2) = UBOUND(buf,1)
-    CALL dummy (buf)
-    after(1) = LBOUND(buf,1)
-    after(2) = UBOUND(buf,1)
+    allocate(buf(n))
+    before(1) = lbound(buf,1)
+    before(2) = ubound(buf,1)
+    call dummy (buf)
+    after(1) = lbound(buf,1)
+    after(2) = ubound(buf,1)
 
-    write(*,'(a20,2i5,l5)') "allocatable lbound", before(1), after(1), before(1) .EQ. after(1)
-    write(*,'(a20,2i5,l5)') "allocatable ubound", before(2), after(2), before(2) .EQ. after(2)
+    write(*,'(a20,2i5,l5)') "allocatable lbound", before(1), after(1), before(1) .eq. after(1)
+    write(*,'(a20,2i5,l5)') "allocatable ubound", before(2), after(2), before(2) .eq. after(2)
 
-    before(1) = LBOUND(buf2,1)
-    before(2) = UBOUND(buf2,1)
-    CALL dummy (buf2)
-    after(1) = LBOUND(buf2,1)
-    after(2) = UBOUND(buf2,1)
+    before(1) = lbound(buf2,1)
+    before(2) = ubound(buf2,1)
+    call dummy (buf2)
+    after(1) = lbound(buf2,1)
+    after(2) = ubound(buf2,1)
 
-    write(*,'(a20,2i5,l5)') "static lbound", before(1), after(1), before(1) .EQ. after(1)
-    write(*,'(a20,2i5,l5)') "static ubound", before(2), after(2), before(2) .EQ. after(2)
-
-END PROGRAM
+    write(*,'(a20,2i5,l5)') "static lbound", before(1), after(1), before(1) .eq. after(1)
+    write(*,'(a20,2i5,l5)') "static ubound", before(2), after(2), before(2) .eq. after(2)
+end program


### PR DESCRIPTION
Makes the "fail" on the gcc test a pass on ReFrame - this way no fails are reported as long as the situation is constant.
If the situation changes, the test will fail, and we can update our documentation.

Also changed:
Fortran formatting
Added project details to the .toml file