### PR TITLE
Test Slurm sets CPU frequency correctly

### DIFF
--- a/tests/env/cpu_freq_check.py
+++ b/tests/env/cpu_freq_check.py
@@ -28,6 +28,7 @@ class CPUFreqTest(rfm.RunOnlyRegressionTest):
         """Sanity check that CPU_CRAY_TARGET is set"""
         return sn.assert_found(f"SLURM_CPU_FREQ_REQ={self.freq}", self.stdout)
 
+
 @rfm.simple_test
 class CPUHighFreqTest(rfm.RunOnlyRegressionTest):
     """Checks that CPU frequency is set to 2.25GHz by default"""

--- a/tests/env/cpu_freq_check.py
+++ b/tests/env/cpu_freq_check.py
@@ -16,7 +16,7 @@ class CPUFreqTest(rfm.RunOnlyRegressionTest):
 
     descr = "Checks whether SLURM_CPU_FREQ_REQ is set to 2GHz as default"
     valid_systems = ["archer2:compute"]
-    valid_prog_environs = ["PrgEnv-cray", "PrgEnv-gnu", "PrgEnv-aocc"]
+    valid_prog_environs = ["PrgEnv-cray"]
     executable = "./freq_print.sh"
 
     tags = {"production", "maintenance", "craype"}
@@ -35,7 +35,7 @@ class CPUHighFreqTest(rfm.RunOnlyRegressionTest):
 
     descr = "Checks whether SLURM_CPU_FREQ_REQ is set to 2GHz as default"
     valid_systems = ["archer2:compute"]
-    valid_prog_environs = ["PrgEnv-cray", "PrgEnv-gnu", "PrgEnv-aocc"]
+    valid_prog_environs = ["PrgEnv-cray"]
     executable = "./freq_print.sh"
 
     tags = {"production", "maintenance", "craype"}

--- a/tests/env/cpu_freq_check.py
+++ b/tests/env/cpu_freq_check.py
@@ -1,0 +1,56 @@
+#!/usr/bin/env python3
+"""Reframe test to check that CPU target environment variable is correctly set"""
+
+# Based on work from:
+#   Copyright 2016-2020 Swiss National Supercomputing Centre (CSCS/ETH Zurich)
+#   ReFrame Project Developers. See the top-level LICENSE file for details.
+#   SPDX-License-Identifier: BSD-3-Clause
+
+import reframe as rfm
+import reframe.utility.sanity as sn
+
+
+@rfm.simple_test
+class CPUFreqTest(rfm.RunOnlyRegressionTest):
+    """Checks that CPU frequency is set to 2GHz by default"""
+
+    descr = "Checks whether SLURM_CPU_FREQ_REQ is set to 2GHz as default"
+    valid_systems = ["archer2:compute"]
+    valid_prog_environs = ["PrgEnv-cray", "PrgEnv-gnu", "PrgEnv-aocc"]
+    #sourcesdir = None
+    executable = "./freq_print.sh"
+
+    tags = {"production", "maintenance", "craype"}
+
+    freq = 2000000
+
+    @sanity_function
+    def assert_finished(self):
+        """Sanity check that CPU_CRAY_TARGET is set"""
+        return sn.assert_found(f"SLURM_CPU_FREQ_REQ={self.freq}", self.stdout)
+
+
+
+
+@rfm.simple_test
+class CPUHighFreqTest(rfm.RunOnlyRegressionTest):
+    """Checks that CPU frequency is set to 2.25GHz by default"""
+
+    descr = "Checks whether SLURM_CPU_FREQ_REQ is set to 2GHz as default"
+    valid_systems = ["archer2:compute"]
+    valid_prog_environs = ["PrgEnv-cray", "PrgEnv-gnu", "PrgEnv-aocc"]
+    #sourcesdir = None
+    executable = "./freq_print.sh"
+
+    tags = {"production", "maintenance", "craype"}
+
+    freq = 2250000
+
+    @run_before('run')
+    def set_cpu_freq(self):
+        self.job.launcher.options = ['--cpu-freq=2250000']
+
+    @sanity_function
+    def assert_finished(self):
+        """Sanity check that CPU_CRAY_TARGET is set"""
+        return sn.assert_found(f"SLURM_CPU_FREQ_REQ={self.freq}", self.stdout)

--- a/tests/env/cpu_freq_check.py
+++ b/tests/env/cpu_freq_check.py
@@ -17,7 +17,6 @@ class CPUFreqTest(rfm.RunOnlyRegressionTest):
     descr = "Checks whether SLURM_CPU_FREQ_REQ is set to 2GHz as default"
     valid_systems = ["archer2:compute"]
     valid_prog_environs = ["PrgEnv-cray", "PrgEnv-gnu", "PrgEnv-aocc"]
-    #sourcesdir = None
     executable = "./freq_print.sh"
 
     tags = {"production", "maintenance", "craype"}
@@ -29,9 +28,6 @@ class CPUFreqTest(rfm.RunOnlyRegressionTest):
         """Sanity check that CPU_CRAY_TARGET is set"""
         return sn.assert_found(f"SLURM_CPU_FREQ_REQ={self.freq}", self.stdout)
 
-
-
-
 @rfm.simple_test
 class CPUHighFreqTest(rfm.RunOnlyRegressionTest):
     """Checks that CPU frequency is set to 2.25GHz by default"""
@@ -39,7 +35,6 @@ class CPUHighFreqTest(rfm.RunOnlyRegressionTest):
     descr = "Checks whether SLURM_CPU_FREQ_REQ is set to 2GHz as default"
     valid_systems = ["archer2:compute"]
     valid_prog_environs = ["PrgEnv-cray", "PrgEnv-gnu", "PrgEnv-aocc"]
-    #sourcesdir = None
     executable = "./freq_print.sh"
 
     tags = {"production", "maintenance", "craype"}
@@ -48,6 +43,7 @@ class CPUHighFreqTest(rfm.RunOnlyRegressionTest):
 
     @run_before('run')
     def set_cpu_freq(self):
+        """Add slurm command line variable to job script to set frequency to 2.25Ghz"""
         self.job.launcher.options = ['--cpu-freq=2250000']
 
     @sanity_function

--- a/tests/env/cpu_freq_check.py
+++ b/tests/env/cpu_freq_check.py
@@ -14,7 +14,7 @@ import reframe.utility.sanity as sn
 class CPUFreqTest(rfm.RunOnlyRegressionTest):
     """Checks that CPU frequency is set to 2GHz by default"""
 
-    descr = "Checks whether SLURM_CPU_FREQ_REQ is set to 2GHz as default"
+    descr = "Checks whether SLURM_CPU_FREQ_REQ is set to 2GHz by default"
     valid_systems = ["archer2:compute"]
     valid_prog_environs = ["PrgEnv-cray"]
     executable = "./freq_print.sh"
@@ -25,15 +25,15 @@ class CPUFreqTest(rfm.RunOnlyRegressionTest):
 
     @sanity_function
     def assert_finished(self):
-        """Sanity check that CPU_CRAY_TARGET is set"""
+        """Sanity check that SLURM_CPU_FREQ_REQ is set"""
         return sn.assert_found(f"SLURM_CPU_FREQ_REQ={self.freq}", self.stdout)
 
 
 @rfm.simple_test
 class CPUHighFreqTest(rfm.RunOnlyRegressionTest):
-    """Checks that CPU frequency is set to 2.25GHz by default"""
+    """Checks that CPU frequency is set to 2.25GHz"""
 
-    descr = "Checks whether SLURM_CPU_FREQ_REQ is set to 2GHz as default"
+    descr = "Checks whether SLURM_CPU_FREQ_REQ can be set to 2.25GHz is set by slurm"
     valid_systems = ["archer2:compute"]
     valid_prog_environs = ["PrgEnv-cray"]
     executable = "./freq_print.sh"
@@ -49,5 +49,5 @@ class CPUHighFreqTest(rfm.RunOnlyRegressionTest):
 
     @sanity_function
     def assert_finished(self):
-        """Sanity check that CPU_CRAY_TARGET is set"""
+        """Sanity check that SLURM_CPU_FREQ_REQ is set"""
         return sn.assert_found(f"SLURM_CPU_FREQ_REQ={self.freq}", self.stdout)

--- a/tests/env/cpu_freq_check.py
+++ b/tests/env/cpu_freq_check.py
@@ -42,10 +42,10 @@ class CPUHighFreqTest(rfm.RunOnlyRegressionTest):
 
     freq = 2250000
 
-    @run_before('run')
+    @run_before("run")
     def set_cpu_freq(self):
         """Add slurm command line variable to job script to set frequency to 2.25Ghz"""
-        self.job.launcher.options = ['--cpu-freq=2250000']
+        self.job.launcher.options = ["--cpu-freq=2250000"]
 
     @sanity_function
     def assert_finished(self):

--- a/tests/env/src/freq_print.sh
+++ b/tests/env/src/freq_print.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+echo SLURM_CPU_FREQ_REQ=$SLURM_CPU_FREQ_REQ


### PR DESCRIPTION
Two tests for Archer2:

1) Slurm job with no --cpu-freq argument has SLURM_CPU_FREQ_REQ=2000000

2) Slurm job with --cpu-freq=2250000 argument has SLURM_CPU_FREQ_REQ=2250000