### PR TITLE
Upgrading to v4.8.2

### DIFF
--- a/tests/apps/castep/castep_check.py
+++ b/tests/apps/castep/castep_check.py
@@ -59,11 +59,11 @@ class CASTEPCPUCheck(CASTEPBaseCheck):
     time_limit = "20m"
     num_cpus_per_task = 1
     env_vars = {"OMP_NUM_THREADS": str(num_cpus_per_task)}
-    reference["archer2:compute"] = { }
+    reference["archer2:compute"] = {}
     reference["archer2:compute"]["calctime"] = (126, -0.1, 0.1, "s")
     reference["archer2:compute"]["runtime"] = (132, -0.1, 0.1, "s")
-    
-    reference["cirrus:compute"] = { }
+
+    reference["cirrus:compute"] = {}
 
     reference["cirrus:compute"]["calctime"] = (325.9, -0.1, 0.1, "s")
     reference["cirrus:compute"]["runtime"] = (328.2, -0.1, 0.1, "s")

--- a/tests/apps/castep/castep_check.py
+++ b/tests/apps/castep/castep_check.py
@@ -59,9 +59,12 @@ class CASTEPCPUCheck(CASTEPBaseCheck):
     time_limit = "20m"
     num_cpus_per_task = 1
     env_vars = {"OMP_NUM_THREADS": str(num_cpus_per_task)}
-
+    reference["archer2:compute"] = { }
     reference["archer2:compute"]["calctime"] = (126, -0.1, 0.1, "s")
     reference["archer2:compute"]["runtime"] = (132, -0.1, 0.1, "s")
+    
+    reference["cirrus:compute"] = { }
+
     reference["cirrus:compute"]["calctime"] = (325.9, -0.1, 0.1, "s")
     reference["cirrus:compute"]["runtime"] = (328.2, -0.1, 0.1, "s")
 

--- a/tests/apps/gromacs/gmx_1400k_atoms.py
+++ b/tests/apps/gromacs/gmx_1400k_atoms.py
@@ -55,6 +55,9 @@ class GromacsCPUCheck(Gromacs1400kAtomsBase):
     num_tasks = 128
     num_cpus_per_task = 1
     env_vars = {"OMP_NUM_THREADS": str(num_cpus_per_task)}
+    reference["archer2:compute"] = {}
+    reference["archer2-tds:compute"] = {}
+    reference["cirrus:compute"] = {}
 
     reference["archer2:compute"]["performance"] = (24.0, -0.1, None, "ns/day")
     reference["archer2-tds:compute"]["performance"] = (22.4, -0.1, None, "ns/day")
@@ -86,7 +89,7 @@ class GromacsGPUCheck(Gromacs1400kAtomsBase):
     n_nodes = 1
     num_tasks = None
     num_cpus_per_tasks = None
-
+    reference["cirrus:compute-gpu"] = {}
     reference["cirrus:compute-gpu"]["performance"] = (11.5, -0.05, None, "ns/day")
 
     @run_after("setup")

--- a/tests/apps/lammps/dipole_large.py
+++ b/tests/apps/lammps/dipole_large.py
@@ -13,7 +13,7 @@ class LAMMPSDipole(LAMMPSBase):
     modules = ["lammps"]
     descr = "Slingshot reliability test using LAMMPS/Dipole"
     executable_opts = ["-i in_2048.dipole"]
-    tags = {"largescale","applications", "performance"}
+    tags = {"largescale", "applications", "performance"}
     n_nodes = 1024
     num_cpus_per_task = 1
     time_limit = "20m"

--- a/tests/apps/lammps/dipole_large.py
+++ b/tests/apps/lammps/dipole_large.py
@@ -13,7 +13,7 @@ class LAMMPSDipole(LAMMPSBase):
     modules = ["lammps"]
     descr = "Slingshot reliability test using LAMMPS/Dipole"
     executable_opts = ["-i in_2048.dipole"]
-
+    tags = {"largescale","applications", "performance"}
     n_nodes = 1024
     num_cpus_per_task = 1
     time_limit = "20m"

--- a/tests/apps/lammps/ethanol.py
+++ b/tests/apps/lammps/ethanol.py
@@ -57,6 +57,9 @@ class LAMMPSEthanolCPU(LAMMPSBaseEthanol):
     descr = LAMMPSBaseEthanol.descr + " -- CPU"
     stream_binary = fixture(BuildLAMMPS, scope="environment")
 
+    reference["archer2-tds:compute"] = {}
+    reference["archer2:compute"] = {}
+    
     reference["archer2:compute"]["performance"] = (11.250, -0.05, None, "ns/day")
     reference["archer2-tds:compute"]["performance"] = (11.250, -0.05, None, "ns/day")
 
@@ -93,7 +96,7 @@ class LAMMPSEthanolGPU(LAMMPSBaseEthanol):
     n_nodes = 1
     num_tasks = None
     num_cpus_per_task = None
-
+    reference["cirrus:compute-gpu"] = {}
     reference["cirrus:compute-gpu"]["performance"] = (9.4, -0.05, None, "ns/day")
 
     @run_after("init")

--- a/tests/apps/lammps/ethanol.py
+++ b/tests/apps/lammps/ethanol.py
@@ -59,7 +59,7 @@ class LAMMPSEthanolCPU(LAMMPSBaseEthanol):
 
     reference["archer2-tds:compute"] = {}
     reference["archer2:compute"] = {}
-    
+
     reference["archer2:compute"]["performance"] = (11.250, -0.05, None, "ns/day")
     reference["archer2-tds:compute"]["performance"] = (11.250, -0.05, None, "ns/day")
 

--- a/tests/apps/xcompact3d/xcompact3d.py
+++ b/tests/apps/xcompact3d/xcompact3d.py
@@ -29,7 +29,6 @@ class XCompact3DLargeTest(rfm.RegressionTest):
 
     time_limit = "1h"
     build_system = "CMake"
-    build_system.ftn = "ftn"
     prebuild_cmds = [
         "git clone https://github.com/xcompact3d/Incompact3d.git",
         "cd Incompact3d",

--- a/tests/synth/benchio/benchio_small.py
+++ b/tests/synth/benchio/benchio_small.py
@@ -54,9 +54,10 @@ class BenchioSmallTest(rfm.RegressionTest):
 
     @run_after("setup")
     def set_references_per_node(self):
+        """set reference values"""
+
         self.num_tasks = 128 * self.num_nodes
 
-        """set reference values"""
         if self.num_nodes == 1:
             self.reference = {
                 "archer2:compute": {

--- a/tests/synth/benchio/benchio_small.py
+++ b/tests/synth/benchio/benchio_small.py
@@ -55,7 +55,7 @@ class BenchioSmallTest(rfm.RegressionTest):
     @run_after("setup")
     def set_references_per_node(self):
         self.num_tasks = 128 * self.num_nodes
-    
+
         """set reference values"""
         if self.num_nodes == 1:
             self.reference = {

--- a/tests/synth/benchio/benchio_small.py
+++ b/tests/synth/benchio/benchio_small.py
@@ -41,7 +41,6 @@ class BenchioSmallTest(rfm.RegressionTest):
     )
 
     executable_opts = ("1260 1260 1260 global mpiio hdf5 fsync").split()
-    num_tasks = 128 * num_nodes
     num_tasks_per_node = 128
     num_cpus_per_task = 1
 
@@ -51,11 +50,12 @@ class BenchioSmallTest(rfm.RegressionTest):
     postrun_cmds = ["source delete_dirs.sh"]
     time_limit = "1h"
     build_system = "CMake"
-    build_system.ftn = "ftn"
     modules = ["cray-hdf5-parallel"]
 
     @run_after("setup")
     def set_references_per_node(self):
+        self.num_tasks = 128 * self.num_nodes
+    
         """set reference values"""
         if self.num_nodes == 1:
             self.reference = {


### PR DESCRIPTION
Version 4.8.2 has a mechanism to compare results from two different runs. This requires minor changes to the tests.
The new version of reframe is available centrally with 

```
module use /mnt/lustre/a2fs-work4/work/y07/shared/archer2-lmod/utils/dev
module load reframe/4.8.2
```

This changes are compatible with the current version of reframe, so should not break any of the current tests.