### PR TITLE
Apps cirrus ex

### DIFF
--- a/tests/apps/castep/castep_check.py
+++ b/tests/apps/castep/castep_check.py
@@ -52,7 +52,7 @@ class CASTEPBaseCheck(rfm.RunOnlyRegressionTest):
 class CASTEPCPUCheck(CASTEPBaseCheck):
     """CASTEP Check for CPU"""
 
-    valid_systems = ["archer2:compute", "cirrus:compute"]
+    valid_systems = ["archer2:compute", "cirrus:compute","cirrus-ex:compute"]
     descr = "CASTEP corrctness and performance test"
     executable_opts = ["al3x3"]
 
@@ -62,11 +62,15 @@ class CASTEPCPUCheck(CASTEPBaseCheck):
     reference["archer2:compute"] = {}
     reference["archer2:compute"]["calctime"] = (126, -0.1, 0.1, "s")
     reference["archer2:compute"]["runtime"] = (132, -0.1, 0.1, "s")
-
+    
     reference["cirrus:compute"] = {}
-
     reference["cirrus:compute"]["calctime"] = (325.9, -0.1, 0.1, "s")
     reference["cirrus:compute"]["runtime"] = (328.2, -0.1, 0.1, "s")
+
+    reference["cirrus-ex:compute"] = {}
+    reference["cirrus-ex:compute"]["runtime"] = (82, -0.1, 0.1, "s")
+    reference["cirrus-ex:compute"]["calctime"] = (74, -0.1, 0.1, "s")
+
 
     @run_after("init")
     def setup_environment(self):
@@ -75,6 +79,11 @@ class CASTEPCPUCheck(CASTEPBaseCheck):
             self.modules = ["castep"]
             self.num_tasks = 512
             self.num_tasks_per_node = 128
+        
+        if self.current_system.name in ["cirrus-ex"]:
+            self.modules = ["castep"]
+            self.num_tasks = 288 * 2
+            self.num_tasks_per_node = 288
 
         if self.current_system.name in ["cirrus"]:
             self.modules = ["castep/22.1.1"]

--- a/tests/apps/castep/castep_check.py
+++ b/tests/apps/castep/castep_check.py
@@ -52,7 +52,7 @@ class CASTEPBaseCheck(rfm.RunOnlyRegressionTest):
 class CASTEPCPUCheck(CASTEPBaseCheck):
     """CASTEP Check for CPU"""
 
-    valid_systems = ["archer2:compute", "cirrus:compute","cirrus-ex:compute"]
+    valid_systems = ["archer2:compute", "cirrus:compute", "cirrus-ex:compute"]
     descr = "CASTEP corrctness and performance test"
     executable_opts = ["al3x3"]
 
@@ -62,7 +62,7 @@ class CASTEPCPUCheck(CASTEPBaseCheck):
     reference["archer2:compute"] = {}
     reference["archer2:compute"]["calctime"] = (126, -0.1, 0.1, "s")
     reference["archer2:compute"]["runtime"] = (132, -0.1, 0.1, "s")
-    
+
     reference["cirrus:compute"] = {}
     reference["cirrus:compute"]["calctime"] = (325.9, -0.1, 0.1, "s")
     reference["cirrus:compute"]["runtime"] = (328.2, -0.1, 0.1, "s")
@@ -71,7 +71,6 @@ class CASTEPCPUCheck(CASTEPBaseCheck):
     reference["cirrus-ex:compute"]["runtime"] = (82, -0.1, 0.1, "s")
     reference["cirrus-ex:compute"]["calctime"] = (74, -0.1, 0.1, "s")
 
-
     @run_after("init")
     def setup_environment(self):
         """Setup environment"""
@@ -79,7 +78,7 @@ class CASTEPCPUCheck(CASTEPBaseCheck):
             self.modules = ["castep"]
             self.num_tasks = 512
             self.num_tasks_per_node = 128
-        
+
         if self.current_system.name in ["cirrus-ex"]:
             self.modules = ["castep"]
             self.num_tasks = 288 * 2

--- a/tests/apps/cp2k/cp2k_check.py
+++ b/tests/apps/cp2k/cp2k_check.py
@@ -4,8 +4,6 @@
 
 import reframe as rfm
 import reframe.utility.sanity as sn
-from reframe.core.backends import register_launcher
-from reframe.core.launchers import JobLauncher
 
 
 class CP2KBaseCheck(rfm.RunOnlyRegressionTest):
@@ -170,7 +168,9 @@ class CP2KCPUCirrusExRegressionTests(CP2KBaseCheck):
         """
         The command to launch the regression tests is a python script executed serially ( not in parallel).
 
-        In this implementation we use pre-run commands. An alternative is to use a custom launcher. However this needs to be specified in the config, in a custom programming environment. I think that solution is worse , because it pollutes a configuration file with test specific logic.
+        In this implementation we use pre-run commands. An alternative is to use a custom launcher.
+        However this needs to be specified in the config, in a custom programming environment.
+        I think that solution is worse , because it pollutes a configuration file with test specific logic.
 
         """
 

--- a/tests/apps/cp2k/cp2k_check.py
+++ b/tests/apps/cp2k/cp2k_check.py
@@ -143,20 +143,18 @@ class CP2KCPUCirrusExRegressionTests(CP2KBaseCheck):
 
     executable_opts = ["-v"]
 
-    # slurm parameters
-    num_tasks = 144
-    num_tasks_per_node = 144
-    num_cpus_per_task = 2
-    time_limit = "20m"
-
     cp2k_src = fixture(FetchCP2K, scope="environment")
 
+<<<<<<< HEAD
     env_vars = {
         "OMP_NUM_THREADS": str(num_cpus_per_task),
         "OMP_PLACES": "cores",
         "CP2K_APP": "$(which cp2k.psmp)",
         "CP2K_DIR": "${CP2K_APP::-10}",
     }
+=======
+    env_vars = {"OMP_PLACES": "cores", "CP2K_APP": "$(which cp2k.psmp)", "CP2K_DIR": "${CP2K_APP::-10}"}
+>>>>>>> 05a6ec6 (Generalised cp2k regression tests to different topologies)
 
     @sanity_function
     def assert_all_tests_completed(self):
@@ -164,12 +162,29 @@ class CP2KCPUCirrusExRegressionTests(CP2KBaseCheck):
         return sn.assert_found("Status: OK", self.stdout)
 
     @run_before("run")
+    def set_resources(self):
+        """Sets up slurm parameters"""
+        # slurm parameters
+        self.num_tasks = self.current_partition.processor.num_cpus // 2
+        self.num_tasks_per_node = self.current_partition.processor.num_cpus // 2
+        self.num_cpus_per_task = 2
+        self.time_limit = "20m"
+        self.env_vars["OMP_NUM_THREADS"] = str(self.num_cpus_per_task)
+
+    @run_before("run")
     def launch_reg_tests(self):
         """
         The command to launch the regression tests is a python script executed serially ( not in parallel).
 
+<<<<<<< HEAD
         In this implementation we use pre-run commands. An alternative is to use a custom launcher.
         However this needs to be specified in the config, in a custom programming environment.
+=======
+        In this implementation we use pre-run commands.
+        An alternative is to use a custom launcher.
+        However this needs to be specified in the config,
+        in a custom programming environment.
+>>>>>>> 05a6ec6 (Generalised cp2k regression tests to different topologies)
         I think that solution is worse , because it pollutes a configuration file with test specific logic.
 
         """

--- a/tests/apps/cp2k/cp2k_check.py
+++ b/tests/apps/cp2k/cp2k_check.py
@@ -1,9 +1,11 @@
 #!/usr/bin/env python3
 
-"""ReFrame test for cp2k"""
+"""ReFrame tests for cp2k"""
 
 import reframe as rfm
 import reframe.utility.sanity as sn
+from reframe.core.backends import register_launcher
+from reframe.core.launchers import JobLauncher
 
 
 class CP2KBaseCheck(rfm.RunOnlyRegressionTest):
@@ -15,25 +17,35 @@ class CP2KBaseCheck(rfm.RunOnlyRegressionTest):
     executable = "cp2k.psmp"
     # Additional Slurm parameters. Requires adding to config file first.
     extra_resources = {"qos": {"qos": "standard"}}
-    # Output files to be retained
-    keep_files = ["cp2k.out"]
-
-    # Set time limit
-
-    time_limit = "20m"
-
+    
     maintainers = ["j.richings@epcc.ed.ac.uk"]
     use_multithreading = False
-    tags = {"applications", "performance"}
+    tags = {"applications"}    
 
+@rfm.simple_test
+class CP2KARCHER2HFX(CP2KBaseCheck):
+    """CP2K performance test"""
+    
+    # Select system to use
+    valid_systems = ["archer2:compute"]
+    # Output files to be retained
+    keep_files = ["cp2k.out"]
+    # Set Programming Environment
+    valid_prog_environs = ["PrgEnv-gnu", "PrgEnv-gnu-hf"]
+    # Description of test
+    descr = "CP2K "
+    # Command line options for executable
+    executable_opts = ("-i input_bulk_HFX_3.inp -o cp2k.out ").split()
+    # different cpu frequencies
+    freq = ["2250000", "2000000"]
+    # slurm parameters
+    num_tasks = 384
+    num_tasks_per_node = 16
+    num_cpus_per_task = 8
+    time_limit = "10m"
     # Reference value to validate run with
     energy_reference = -870.934788
-
-    reference = {
-        "*": {"energy": (energy_reference, -0.01, 0.01, "a.u.")},
-        "cirrus:compute": {"performance": (1300, -0.05, 0.05, "seconds")},
-    }
-
+    tags = CP2KBaseCheck.tags.union({"performance"})
     reference_performance = {
         "2000000": (350, -0.1, 0.1, "seconds"),
         "2250000": (250, -0.1, 0.1, "seconds"),
@@ -43,6 +55,32 @@ class CP2KBaseCheck(rfm.RunOnlyRegressionTest):
     def assert_finished(self):
         """Sanity check that simulation finished successfully"""
         return sn.assert_found("CP2K   ", self.keep_files[0])
+
+    @run_after("init")
+    def setup_params(self):
+        """sets up extra parameters"""
+        # self.descr += self.freq
+        if self.current_system.name in ["archer2"]:
+            self.env_vars = {"OMP_NUM_THREADS": str(self.num_cpus_per_task), 
+            "OMP_PLACES": "cores"
+            }
+
+    @run_before("performance")
+    def set_reference(self):
+        """Changes reference values"""
+        if self.current_system.name in ["archer2"]:
+            # https://reframe-hpc.readthedocs.io/en/stable/utility_functions_reference.html#reframe.utility.ScopedDict
+            self.reference["archer2:compute:performance"] = self.reference_performance[
+                "2250000" if self.current_environ.name[-3:] == "-hf" else "2000000"
+            ]
+    reference = {
+        "*": {"energy": (energy_reference, -0.01, 0.01, "a.u.")}
+    }
+
+    reference_performance = {
+        "2000000": (350, -0.1, 0.1, "seconds"),
+        "2250000": (250, -0.1, 0.1, "seconds"),
+    }
 
     @performance_function("a.u.", perf_key="energy")
     def extract_energy(self):
@@ -66,69 +104,86 @@ class CP2KBaseCheck(rfm.RunOnlyRegressionTest):
 
 
 @rfm.simple_test
-class CP2KARCHER2(CP2KBaseCheck):
-    """CP2K test"""
+class FetchCP2K(rfm.RunOnlyRegressionTest):
+    """
+    Fetch CP2K source code, which contains the regression tests and benchmarks. 
+    """
 
-    # Select system to use
-    valid_systems = ["archer2:compute"]
-    # Set Programming Environment
-    valid_prog_environs = ["PrgEnv-gnu", "PrgEnv-gnu-hf"]
-    # Description of test
-    descr = "CP2K "
-    # Command line options for executable
-    executable_opts = ("-i input_bulk_HFX_3.inp -o cp2k.out ").split()
-    # different cpu frequencies
-    freq = ["2250000", "2000000"]
-    # slurm parameters
-    num_tasks = 384
-    num_tasks_per_node = 16
-    num_cpus_per_task = 8
-    time_limit = "10m"
+    descr = "Fetch cp2k code"
+    version = variable(str, value="2025.2")
+    executable = "wget"
+    executable_opts = [f"https://github.com/cp2k/cp2k/archive/refs/tags/v{version}.tar.gz"]
+    local = True
+    valid_systems = ["cirrus-ex:login"]
+    valid_prog_environs = ["*"]
 
-    reference_performance = {
-        "2000000": (350, -0.1, 0.1, "seconds"),
-        "2250000": (250, -0.1, 0.1, "seconds"),
-    }
-
-    @run_after("init")
-    def setup_params(self):
-        """sets up extra parameters"""
-        # self.descr += self.freq
-        if self.current_system.name in ["archer2"]:
-            self.env_vars = {"OMP_NUM_THREADS": str(self.num_cpus_per_task), "OMP_PLACES": "cores"}
-
-    #                "SLURM_CPU_FREQ_REQ": self.freq,
-    #            }
-
-    @run_before("performance")
-    def set_reference(self):
-        """Changes reference values"""
-        if self.current_system.name in ["archer2"]:
-            # https://reframe-hpc.readthedocs.io/en/stable/utility_functions_reference.html#reframe.utility.ScopedDict
-            self.reference["archer2:compute:performance"] = self.reference_performance[
-                "2250000" if self.current_environ.name[-3:] == "-hf" else "2000000"
-            ]
-
+    @sanity_function
+    def validate_download(self):
+        """Validate the download was successful"""
+        return sn.assert_eq(self.job.exitcode, 0)
 
 @rfm.simple_test
-class CP2KCPUCirrus(CP2KBaseCheck):
-    """CP2K test for Cirrus"""
+class CP2KCPUCirrusExRegressionTests(CP2KBaseCheck):
+    """
+    CP2K regression tests for cirrus-ex
+
+    This runs the CP2K tests from the CP2K regression test suite.
+    They are good functionality tests but not very useful for performance.
+
+    """
 
     # Select system to use
-    valid_systems = ["cirrus:compute"]
+    valid_systems = ["cirrus-ex:compute"]
     # Set Programming Environment
-    valid_prog_environs = ["gcc"]
+    valid_prog_environs = ["PrgEnv-gnu"]
     # Description of test
-    descr = "CP2K test"
+    descr = "CP2K regression tests"
+    launcher="cp2k_reg_tests"    
+    
     # Command line options for executable
-    executable_opts = ("-i input_bulk_HFX_3.inp -o cp2k.out ").split()
+    
+    executable = "cp2k.psmp"
+
+    executable_opts = ["-v"]
+
     # slurm parameters
-    num_tasks = 360
-    num_tasks_per_node = 18
+    num_tasks = 144
+    num_tasks_per_node = 144
     num_cpus_per_task = 2
-    time_limit = "1h"
+    time_limit = "20m"
+
+    cp2k_src = fixture(FetchCP2K, scope="environment")
 
     env_vars = {
         "OMP_NUM_THREADS": str(num_cpus_per_task),
         "OMP_PLACES": "cores",
+        "CP2K_APP" : "$(which cp2k.psmp)",
+        "CP2K_DIR" : "${CP2K_APP::-10}"
     }
+
+    @sanity_function
+    def assert_all_tests_completed(self):
+        """Sanity check that simulation finished successfully"""
+        return sn.assert_found("Status: OK",self.stdout)
+
+    @run_before("run")
+    def launch_reg_tests(self):
+        """
+        The command to launch the regression tests is a python script executed serially ( not in parallel).
+
+        In this implementation we use pre-run commands. An alternative is to use a custom launcher. However this needs to be specified in the config, in a custom programming environment. I think that solution is worse , because it pollutes a configuration file with test specific logic.
+
+        """
+        
+        source_tar_file=f"v{self.cp2k_src.version}.tar.gz"
+
+        self.prerun_cmds = [
+            f"cp {self.cp2k_src.stagedir}/{source_tar_file} .",
+            f"tar -zxf {source_tar_file}",
+            f"cp2k-{self.cp2k_src.version}/tests/do_regtest.py \
+        --workbasedir=$(pwd) \
+        --maxtasks=72 \
+        --mpiranks=2 \
+        --ompthreads=${{OMP_NUM_THREADS}} \
+        --mpiexec=\"srun --ntasks=2 --cpus-per-task=${{OMP_NUM_THREADS}}\" \
+        $CP2K_DIR psmp" ]

--- a/tests/apps/cp2k/cp2k_check.py
+++ b/tests/apps/cp2k/cp2k_check.py
@@ -145,16 +145,7 @@ class CP2KCPUCirrusExRegressionTests(CP2KBaseCheck):
 
     cp2k_src = fixture(FetchCP2K, scope="environment")
 
-<<<<<<< HEAD
-    env_vars = {
-        "OMP_NUM_THREADS": str(num_cpus_per_task),
-        "OMP_PLACES": "cores",
-        "CP2K_APP": "$(which cp2k.psmp)",
-        "CP2K_DIR": "${CP2K_APP::-10}",
-    }
-=======
     env_vars = {"OMP_PLACES": "cores", "CP2K_APP": "$(which cp2k.psmp)", "CP2K_DIR": "${CP2K_APP::-10}"}
->>>>>>> 05a6ec6 (Generalised cp2k regression tests to different topologies)
 
     @sanity_function
     def assert_all_tests_completed(self):
@@ -176,15 +167,10 @@ class CP2KCPUCirrusExRegressionTests(CP2KBaseCheck):
         """
         The command to launch the regression tests is a python script executed serially ( not in parallel).
 
-<<<<<<< HEAD
-        In this implementation we use pre-run commands. An alternative is to use a custom launcher.
-        However this needs to be specified in the config, in a custom programming environment.
-=======
         In this implementation we use pre-run commands.
         An alternative is to use a custom launcher.
         However this needs to be specified in the config,
         in a custom programming environment.
->>>>>>> 05a6ec6 (Generalised cp2k regression tests to different topologies)
         I think that solution is worse , because it pollutes a configuration file with test specific logic.
 
         """

--- a/tests/apps/cp2k/cp2k_check.py
+++ b/tests/apps/cp2k/cp2k_check.py
@@ -17,15 +17,16 @@ class CP2KBaseCheck(rfm.RunOnlyRegressionTest):
     executable = "cp2k.psmp"
     # Additional Slurm parameters. Requires adding to config file first.
     extra_resources = {"qos": {"qos": "standard"}}
-    
+
     maintainers = ["j.richings@epcc.ed.ac.uk"]
     use_multithreading = False
-    tags = {"applications"}    
+    tags = {"applications"}
+
 
 @rfm.simple_test
 class CP2KARCHER2HFX(CP2KBaseCheck):
     """CP2K performance test"""
-    
+
     # Select system to use
     valid_systems = ["archer2:compute"]
     # Output files to be retained
@@ -61,9 +62,7 @@ class CP2KARCHER2HFX(CP2KBaseCheck):
         """sets up extra parameters"""
         # self.descr += self.freq
         if self.current_system.name in ["archer2"]:
-            self.env_vars = {"OMP_NUM_THREADS": str(self.num_cpus_per_task), 
-            "OMP_PLACES": "cores"
-            }
+            self.env_vars = {"OMP_NUM_THREADS": str(self.num_cpus_per_task), "OMP_PLACES": "cores"}
 
     @run_before("performance")
     def set_reference(self):
@@ -73,9 +72,8 @@ class CP2KARCHER2HFX(CP2KBaseCheck):
             self.reference["archer2:compute:performance"] = self.reference_performance[
                 "2250000" if self.current_environ.name[-3:] == "-hf" else "2000000"
             ]
-    reference = {
-        "*": {"energy": (energy_reference, -0.01, 0.01, "a.u.")}
-    }
+
+    reference = {"*": {"energy": (energy_reference, -0.01, 0.01, "a.u.")}}
 
     reference_performance = {
         "2000000": (350, -0.1, 0.1, "seconds"),
@@ -106,7 +104,7 @@ class CP2KARCHER2HFX(CP2KBaseCheck):
 @rfm.simple_test
 class FetchCP2K(rfm.RunOnlyRegressionTest):
     """
-    Fetch CP2K source code, which contains the regression tests and benchmarks. 
+    Fetch CP2K source code, which contains the regression tests and benchmarks.
     """
 
     descr = "Fetch cp2k code"
@@ -116,12 +114,12 @@ class FetchCP2K(rfm.RunOnlyRegressionTest):
     local = True
     valid_systems = ["cirrus-ex:login"]
     valid_prog_environs = ["PgEnv-gnu"]
-    
 
     @sanity_function
     def validate_download(self):
         """Validate the download was successful"""
         return sn.assert_eq(self.job.exitcode, 0)
+
 
 @rfm.simple_test
 class CP2KCPUCirrusExRegressionTests(CP2KBaseCheck):
@@ -139,10 +137,10 @@ class CP2KCPUCirrusExRegressionTests(CP2KBaseCheck):
     valid_prog_environs = ["PrgEnv-gnu"]
     # Description of test
     descr = "CP2K regression tests"
-    launcher="cp2k_reg_tests"    
-    
+    launcher = "cp2k_reg_tests"
+
     # Command line options for executable
-    
+
     executable = "cp2k.psmp"
 
     executable_opts = ["-v"]
@@ -158,14 +156,14 @@ class CP2KCPUCirrusExRegressionTests(CP2KBaseCheck):
     env_vars = {
         "OMP_NUM_THREADS": str(num_cpus_per_task),
         "OMP_PLACES": "cores",
-        "CP2K_APP" : "$(which cp2k.psmp)",
-        "CP2K_DIR" : "${CP2K_APP::-10}"
+        "CP2K_APP": "$(which cp2k.psmp)",
+        "CP2K_DIR": "${CP2K_APP::-10}",
     }
 
     @sanity_function
     def assert_all_tests_completed(self):
         """Sanity check that simulation finished successfully"""
-        return sn.assert_found("Status: OK",self.stdout)
+        return sn.assert_found("Status: OK", self.stdout)
 
     @run_before("run")
     def launch_reg_tests(self):
@@ -175,16 +173,17 @@ class CP2KCPUCirrusExRegressionTests(CP2KBaseCheck):
         In this implementation we use pre-run commands. An alternative is to use a custom launcher. However this needs to be specified in the config, in a custom programming environment. I think that solution is worse , because it pollutes a configuration file with test specific logic.
 
         """
-        
-        source_tar_file=f"v{self.cp2k_src.version}.tar.gz"
+
+        source_tar_file = f"v{self.cp2k_src.version}.tar.gz"
 
         self.prerun_cmds = [
             f"cp {self.cp2k_src.stagedir}/{source_tar_file} .",
             f"tar -zxf {source_tar_file}",
-            f"cp2k-{self.cp2k_src.version}/tests/do_regtest.py \
+            f'cp2k-{self.cp2k_src.version}/tests/do_regtest.py \
         --workbasedir=$(pwd) \
         --maxtasks=72 \
         --mpiranks=2 \
         --ompthreads=${{OMP_NUM_THREADS}} \
-        --mpiexec=\"srun --ntasks=2 --cpus-per-task=${{OMP_NUM_THREADS}}\" \
-        $CP2K_DIR psmp" ]
+        --mpiexec="srun --ntasks=2 --cpus-per-task=${{OMP_NUM_THREADS}}" \
+        $CP2K_DIR psmp',
+        ]

--- a/tests/apps/cp2k/cp2k_check.py
+++ b/tests/apps/cp2k/cp2k_check.py
@@ -115,7 +115,8 @@ class FetchCP2K(rfm.RunOnlyRegressionTest):
     executable_opts = [f"https://github.com/cp2k/cp2k/archive/refs/tags/v{version}.tar.gz"]
     local = True
     valid_systems = ["cirrus-ex:login"]
-    valid_prog_environs = ["*"]
+    valid_prog_environs = ["PgEnv-gnu"]
+    
 
     @sanity_function
     def validate_download(self):

--- a/tests/apps/lammps/dipole_large.py
+++ b/tests/apps/lammps/dipole_large.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python3
 """ReFrame script for lammps dipole test"""
+
 import reframe as rfm
 
 from lammps_base import LAMMPSBase

--- a/tests/apps/lammps/ethanol.py
+++ b/tests/apps/lammps/ethanol.py
@@ -34,6 +34,7 @@ class LAMMPSBaseEthanol(LAMMPSBase):
     reference = {
         "cirrus:compute-gpu": {"energy": (ethanol_energy_reference, -0.01, 0.01, "kJ/mol")},
         "archer2:compute": {"energy": (ethanol_energy_reference, -0.01, 0.01, "kJ/mol")},
+        "cirrus-ex:compute": {"energy": (ethanol_energy_reference, -0.01, 0.01, "kJ/mol")},
         "archer2-tds:compute": {"energy": (ethanol_energy_reference, -0.01, 0.01, "kJ/mol")},
     }
 
@@ -49,25 +50,28 @@ class LAMMPSBaseEthanol(LAMMPSBase):
         )
 
 
-@rfm.simple_test
 class LAMMPSEthanolCPU(LAMMPSBaseEthanol):
     """ReFrame LAMMPS Ethanol test for performance checks"""
 
-    valid_systems = ["archer2:compute"]
     descr = LAMMPSBaseEthanol.descr + " -- CPU"
-    stream_binary = fixture(BuildLAMMPS, scope="environment")
-
+    
     reference["archer2-tds:compute"] = {}
     reference["archer2:compute"] = {}
+    reference["cirrus-ex:compute"] = {}
 
     reference["archer2:compute"]["performance"] = (11.250, -0.05, None, "ns/day")
-    reference["archer2-tds:compute"]["performance"] = (11.250, -0.05, None, "ns/day")
+    reference["cirrus-ex:compute"]["performance"] = (27.56, -0.05, None, "ns/day")
 
+    reference["archer2-tds:compute"]["performance"] = (11.250, -0.05, None, "ns/day")
+    
     @run_after("init")
     def setup_nnodes(self):
         """sets up number of tasks per node"""
         if self.current_system.name in ["archer2"]:
             self.num_tasks_per_node = 128
+        else:
+            if self.current_system.name in ["cirrus-ex"]:
+                self.num_tasks_per_node = 288
 
     @run_after("setup")
     def set_executable(self):
@@ -77,8 +81,33 @@ class LAMMPSEthanolCPU(LAMMPSBaseEthanol):
     @run_before("run")
     def setup_resources(self):
         """sets up number of tasks"""
-        self.num_tasks = self.n_nodes * self.cores.get(self.current_partition.fullname, 1)
+        self.num_tasks = self.n_nodes * self.num_tasks_per_node
 
+@rfm.simple_test
+class LAMMPSEthanolCPURunReframeBuild(LAMMPSEthanolCPU):
+    """ReFrame LAMMPS Ethanol test for performance checks of the reframe-built executable"""
+
+    valid_systems = ["archer2:compute"]
+    descr = LAMMPSEthanolCPU.descr + ", reframe-bult-executable -- CPU"
+    stream_binary = fixture(BuildLAMMPS, scope="environment")
+
+    @run_after("setup")
+    def set_executable(self):
+        """sets up executable"""
+        self.executable = os.path.join(self.stream_binary.build_system.builddir, "lmp")
+
+
+@rfm.simple_test
+class LAMMPSEthanolCPURunModule(LAMMPSEthanolCPU):
+    """ReFrame LAMMPS Ethanol test for performance checks of the default lammps module"""
+
+    valid_systems = ["archer2:compute","cirrus-ex:compute"]
+    descr = LAMMPSEthanolCPU.descr + ", default lammps module -- CPU"
+    
+    @run_after("setup")
+    def set_executable(self):
+        """sets up executable"""
+        self.executable = "lmp"
 
 @rfm.simple_test
 class LAMMPSEthanolGPU(LAMMPSBaseEthanol):

--- a/tests/apps/lammps/ethanol.py
+++ b/tests/apps/lammps/ethanol.py
@@ -137,7 +137,9 @@ class LAMMPSEthanolGPU(LAMMPSBaseEthanol):
         if self.current_system.name in ["archer2"]:
             # self.num_tasks_per_node = 32
             self.extra_resources["qos"] = {"qos": "gpu-exc"}
-            self.executable_opts = LAMMPSBaseEthanol.executable_opts + ["-k on g 4 -sf kk -pk kokkos newton on neigh half"]
+            self.executable_opts = LAMMPSBaseEthanol.executable_opts + [
+                "-k on g 4 -sf kk -pk kokkos newton on neigh half"
+            ]
         elif self.current_system.name in ["cirrus"]:
             self.executable_opts = LAMMPSBaseEthanol.executable_opts + ["-sf gpu -pk gpu 4"]
             self.extra_resources["qos"] = {"qos": "short"}

--- a/tests/apps/lammps/ethanol.py
+++ b/tests/apps/lammps/ethanol.py
@@ -54,7 +54,7 @@ class LAMMPSEthanolCPU(LAMMPSBaseEthanol):
     """ReFrame LAMMPS Ethanol test for performance checks"""
 
     descr = LAMMPSBaseEthanol.descr + " -- CPU"
-    
+
     reference["archer2-tds:compute"] = {}
     reference["archer2:compute"] = {}
     reference["cirrus-ex:compute"] = {}
@@ -63,7 +63,7 @@ class LAMMPSEthanolCPU(LAMMPSBaseEthanol):
     reference["cirrus-ex:compute"]["performance"] = (27.56, -0.05, None, "ns/day")
 
     reference["archer2-tds:compute"]["performance"] = (11.250, -0.05, None, "ns/day")
-    
+
     @run_after("init")
     def setup_nnodes(self):
         """sets up number of tasks per node"""
@@ -83,6 +83,7 @@ class LAMMPSEthanolCPU(LAMMPSBaseEthanol):
         """sets up number of tasks"""
         self.num_tasks = self.n_nodes * self.num_tasks_per_node
 
+
 @rfm.simple_test
 class LAMMPSEthanolCPURunReframeBuild(LAMMPSEthanolCPU):
     """ReFrame LAMMPS Ethanol test for performance checks of the reframe-built executable"""
@@ -101,13 +102,14 @@ class LAMMPSEthanolCPURunReframeBuild(LAMMPSEthanolCPU):
 class LAMMPSEthanolCPURunModule(LAMMPSEthanolCPU):
     """ReFrame LAMMPS Ethanol test for performance checks of the default lammps module"""
 
-    valid_systems = ["archer2:compute","cirrus-ex:compute"]
+    valid_systems = ["archer2:compute", "cirrus-ex:compute"]
     descr = LAMMPSEthanolCPU.descr + ", default lammps module -- CPU"
-    
+
     @run_after("setup")
     def set_executable(self):
         """sets up executable"""
         self.executable = "lmp"
+
 
 @rfm.simple_test
 class LAMMPSEthanolGPU(LAMMPSBaseEthanol):
@@ -135,9 +137,7 @@ class LAMMPSEthanolGPU(LAMMPSBaseEthanol):
         if self.current_system.name in ["archer2"]:
             # self.num_tasks_per_node = 32
             self.extra_resources["qos"] = {"qos": "gpu-exc"}
-            self.executable_opts = LAMMPSBaseEthanol.executable_opts + [
-                "-k on g 4 -sf kk -pk kokkos newton on neigh half"
-            ]
+            self.executable_opts = LAMMPSBaseEthanol.executable_opts + ["-k on g 4 -sf kk -pk kokkos newton on neigh half"]
         elif self.current_system.name in ["cirrus"]:
             self.executable_opts = LAMMPSBaseEthanol.executable_opts + ["-sf gpu -pk gpu 4"]
             self.extra_resources["qos"] = {"qos": "short"}

--- a/tests/apps/nektarpp/test_nektarpp.py
+++ b/tests/apps/nektarpp/test_nektarpp.py
@@ -11,7 +11,6 @@ import os
 import reframe as rfm
 import reframe.utility.sanity as sn
 
-
 NEKTAR_VERSION = "5.5.0"
 NEKTAR_LABEL = "nektar"
 NEKTAR_ARCHIVE = f"{NEKTAR_LABEL}-v{NEKTAR_VERSION}.tar.gz"

--- a/tests/apps/openfoam/openfoam_org_base.py
+++ b/tests/apps/openfoam/openfoam_org_base.py
@@ -10,7 +10,7 @@ class OpenFOAMBase(rfm.RunOnlyRegressionTest):
     v_major = "10"
     v_patch = "20230119"
     version = f"{v_major}.{v_patch}"
-    valid_systems = ["archer2:compute"]
+    valid_systems = ["archer2:compute","cirrus-ex:compute"]
     valid_prog_environs = ["PrgEnv-gnu"]
 
     maintainers = ["e.broadway@epcc.ed.ac.uk", "j.richings@epcc.ed.ac.uk"]

--- a/tests/apps/openfoam/openfoam_org_base.py
+++ b/tests/apps/openfoam/openfoam_org_base.py
@@ -6,11 +6,10 @@ import reframe.utility.sanity as sn
 
 class OpenFOAMBase(rfm.RunOnlyRegressionTest):
     """ReFrame OpenFOAM test base class"""
-
-    v_major = "10"
+    
+    v_major = "12"
     v_patch = "20230119"
     version = f"{v_major}.{v_patch}"
-    valid_systems = ["archer2:compute","cirrus-ex:compute"]
     valid_prog_environs = ["PrgEnv-gnu"]
 
     maintainers = ["e.broadway@epcc.ed.ac.uk", "j.richings@epcc.ed.ac.uk"]

--- a/tests/apps/openfoam/openfoam_org_base.py
+++ b/tests/apps/openfoam/openfoam_org_base.py
@@ -12,6 +12,10 @@ class OpenFOAMBase(rfm.RunOnlyRegressionTest):
     use_multithreading = False
     tags = {"applications", "performance"}
 
+    v_major = None
+    v_patch = None
+    version = None
+
     @run_after("init")
     def set_version_vars(self):
         """sets up version variables"""

--- a/tests/apps/openfoam/openfoam_org_base.py
+++ b/tests/apps/openfoam/openfoam_org_base.py
@@ -7,11 +7,9 @@ import reframe.utility.sanity as sn
 class OpenFOAMBase(rfm.RunOnlyRegressionTest):
     """ReFrame OpenFOAM test base class"""
     
-    v_major = "12"
-    v_patch = "20230119"
-    version = f"{v_major}.{v_patch}"
+ 
     valid_prog_environs = ["PrgEnv-gnu"]
-
+    
     maintainers = ["e.broadway@epcc.ed.ac.uk", "j.richings@epcc.ed.ac.uk"]
     use_multithreading = False
     tags = {"applications", "performance"}
@@ -30,3 +28,20 @@ class OpenFOAMBase(rfm.RunOnlyRegressionTest):
             "time",
             float,
         )
+    @run_after("init")
+    def set_version_vars(self):
+        """sets up version variables"""
+
+        if self.current_system.name in ["archer2"]:
+            self.v_major = "10"
+            self.v_patch = "20230119" 
+        if self.current_system.name in ["cirrus-ex"]:
+            self.v_major = "12"
+            self.v_patch = "0"
+        else:
+            raise ValueError(f"OpenFoam version for System {self.current_system.name} not recognised .")
+        self.version = f"{self.v_major}-{self.v_patch}"
+        
+
+ 
+

--- a/tests/apps/openfoam/openfoam_org_base.py
+++ b/tests/apps/openfoam/openfoam_org_base.py
@@ -14,20 +14,7 @@ class OpenFOAMBase(rfm.RunOnlyRegressionTest):
     use_multithreading = False
     tags = {"applications", "performance"}
 
-    @sanity_function
-    def assert_finished(self):
-        """Sanity check that simulation finished successfully"""
-        return sn.assert_found("End", self.stdout)
 
-    @performance_function("seconds", perf_key="performance")
-    def extract_perf(self):
-        """Extract performance value to compare with reference value"""
-        return sn.extractsingle(
-            r"ExecutionTime\s+=\s+(?P<time>\d+.?\d*\s+)s\s+ClockTime\s+=\s+\d*\s+s\n\nEnd",
-            self.stdout,
-            "time",
-            float,
-        )
     @run_after("init")
     def set_version_vars(self):
         """sets up version variables"""
@@ -35,12 +22,14 @@ class OpenFOAMBase(rfm.RunOnlyRegressionTest):
         if self.current_system.name in ["archer2"]:
             self.v_major = "10"
             self.v_patch = "20230119" 
-        if self.current_system.name in ["cirrus-ex"]:
-            self.v_major = "12"
-            self.v_patch = "0"
         else:
-            raise ValueError(f"OpenFoam version for System {self.current_system.name} not recognised .")
-        self.version = f"{self.v_major}-{self.v_patch}"
+            if self.current_system.name in ["cirrus-ex"]:
+                self.v_major = "12"
+                self.v_patch = "0"
+            else:
+                raise ValueError(f"OpenFoam version for System {self.current_system.name} not recognised .")
+        
+        self.version = f"{self.v_major}.{self.v_patch}"
         
 
  

--- a/tests/apps/openfoam/openfoam_org_base.py
+++ b/tests/apps/openfoam/openfoam_org_base.py
@@ -6,14 +6,12 @@ import reframe.utility.sanity as sn
 
 class OpenFOAMBase(rfm.RunOnlyRegressionTest):
     """ReFrame OpenFOAM test base class"""
-    
- 
+
     valid_prog_environs = ["PrgEnv-gnu"]
-    
+
     maintainers = ["e.broadway@epcc.ed.ac.uk", "j.richings@epcc.ed.ac.uk"]
     use_multithreading = False
     tags = {"applications", "performance"}
-
 
     @run_after("init")
     def set_version_vars(self):
@@ -21,16 +19,12 @@ class OpenFOAMBase(rfm.RunOnlyRegressionTest):
 
         if self.current_system.name in ["archer2"]:
             self.v_major = "10"
-            self.v_patch = "20230119" 
+            self.v_patch = "20230119"
         else:
             if self.current_system.name in ["cirrus-ex"]:
                 self.v_major = "12"
                 self.v_patch = "0"
             else:
                 raise ValueError(f"OpenFoam version for System {self.current_system.name} not recognised .")
-        
+
         self.version = f"{self.v_major}.{self.v_patch}"
-        
-
- 
-

--- a/tests/apps/openfoam/openfoam_org_base.py
+++ b/tests/apps/openfoam/openfoam_org_base.py
@@ -1,7 +1,6 @@
 """Base class for OpenFoam.org tests"""
 
 import reframe as rfm
-import reframe.utility.sanity as sn
 
 
 class OpenFOAMBase(rfm.RunOnlyRegressionTest):

--- a/tests/apps/openfoam/openfoam_org_build.py
+++ b/tests/apps/openfoam/openfoam_org_build.py
@@ -14,7 +14,6 @@ class FetchOpenFOAM(OpenFOAMBase):
     valid_systems = ["archer2:login"]
     executable = "bash"
 
-    
     @run_before("run")
     def set_args(self):
         """sets up download commands"""
@@ -27,7 +26,7 @@ class FetchOpenFOAM(OpenFOAMBase):
             http://dl.openfoam.org/third-party/{self.v_major}
             """,
         ]
-       
+
     @sanity_function
     def validate_download(self):
         """Validate OpenFoam Downloaded"""

--- a/tests/apps/openfoam/openfoam_org_build.py
+++ b/tests/apps/openfoam/openfoam_org_build.py
@@ -5,7 +5,7 @@ import reframe.utility.sanity as sn
 from openfoam_org_base import OpenFOAMBase
 
 
-class FetchOpenFOAM(rfm.RunOnlyRegressionTest):
+class FetchOpenFOAM(OpenFOAMBase):
     """Download OpenFoam"""
 
     local = True
@@ -15,10 +15,10 @@ class FetchOpenFOAM(rfm.RunOnlyRegressionTest):
     executable = "bash"
 
     
-    @run_after("init")
+    @run_before("run")
     def set_args(self):
         """sets up download commands"""
-        executable_opts = [
+        self.executable_opts = [
             "-c",
             f"""
             wget -O OpenFOAM-{self.v_major}-{self.v_patch}.tar.gz \
@@ -27,7 +27,7 @@ class FetchOpenFOAM(rfm.RunOnlyRegressionTest):
             http://dl.openfoam.org/third-party/{self.v_major}
             """,
         ]
-    
+       
     @sanity_function
     def validate_download(self):
         """Validate OpenFoam Downloaded"""

--- a/tests/apps/openfoam/openfoam_org_build.py
+++ b/tests/apps/openfoam/openfoam_org_build.py
@@ -13,23 +13,28 @@ class FetchOpenFOAM(rfm.RunOnlyRegressionTest):
 
     valid_systems = ["archer2:login"]
     executable = "bash"
-    executable_opts = [
-        "-c",
-        f"""
-        wget -O OpenFOAM-{OpenFOAMBase.v_major}-{OpenFOAMBase.v_patch}.tar.gz \
-        http://dl.openfoam.org/source/{OpenFOAMBase.version} &&
-        wget -O ThirdParty-{OpenFOAMBase.v_major}-version-{OpenFOAMBase.v_major}.tar.gz \
-        http://dl.openfoam.org/third-party/{OpenFOAMBase.v_major}
-        """,
-    ]
 
+    
+    @run_after("init")
+    def set_args(self):
+        """sets up download commands"""
+        executable_opts = [
+            "-c",
+            f"""
+            wget -O OpenFOAM-{self.v_major}-{self.v_patch}.tar.gz \
+            http://dl.openfoam.org/source/{self.version} &&
+            wget -O ThirdParty-{self.v_major}-version-{self.v_major}.tar.gz \
+            http://dl.openfoam.org/third-party/{self.v_major}
+            """,
+        ]
+    
     @sanity_function
     def validate_download(self):
         """Validate OpenFoam Downloaded"""
         return sn.all(
             [
-                sn.path_isfile(f"OpenFOAM-{OpenFOAMBase.v_major}-{OpenFOAMBase.v_patch}.tar.gz"),
-                sn.path_isfile(f"ThirdParty-{OpenFOAMBase.v_major}-version-{OpenFOAMBase.v_major}.tar.gz"),
+                sn.path_isfile(f"OpenFOAM-{self.v_major}-{self.v_patch}.tar.gz"),
+                sn.path_isfile(f"ThirdParty-{self.v_major}-version-{self.v_major}.tar.gz"),
             ]
         )
 

--- a/tests/apps/openfoam/openfoam_org_dambreak.py
+++ b/tests/apps/openfoam/openfoam_org_dambreak.py
@@ -183,6 +183,7 @@ class OpenFOAMDamBreakParallelModule(OpenFOAMDamBreakParallel):
 
     @run_before("run")
     def load_modules(self):
+        "Loads modules based on current system"
         if self.current_system.name in ["archer2"]:
             self.modules = [f"openfoam/org/v{self.version}"]
         elif self.current_system.name in ["cirrus-ex"]:

--- a/tests/apps/openfoam/openfoam_org_dambreak.py
+++ b/tests/apps/openfoam/openfoam_org_dambreak.py
@@ -135,7 +135,9 @@ class OpenFOAMDamBreakOneNodeBuild(OpenFOAMDamBreakOneNode):
     def setup_extra_params(self):
         """sets up extra parameters"""
         super().setup_params()
-        self.env_vars.update({"FOAM_INSTALL_DIR": os.path.join(self.interfoam_binary.stagedir, f"OpenFOAM-{self.v_major}")})
+        self.env_vars.update(
+            {"FOAM_INSTALL_DIR": os.path.join(self.interfoam_binary.stagedir, f"OpenFOAM-{self.v_major}")}
+        )
 
     @run_after("setup")
     def set_executable(self):
@@ -196,7 +198,9 @@ class OpenFOAMDamBreakParallelBuild(OpenFOAMDamBreakParallel):
     def setup_extra_params(self):
         """sets up extra parameters"""
         super().setup_params()
-        self.env_vars.update({"FOAM_INSTALL_DIR": os.path.join(self.interfoam_binary.stagedir, f"OpenFOAM-{self.v_major}")})
+        self.env_vars.update(
+            {"FOAM_INSTALL_DIR": os.path.join(self.interfoam_binary.stagedir, f"OpenFOAM-{self.v_major}")}
+        )
 
     @run_after("setup")
     def set_executable(self):

--- a/tests/apps/openfoam/openfoam_org_dambreak.py
+++ b/tests/apps/openfoam/openfoam_org_dambreak.py
@@ -12,19 +12,34 @@ class OpenFOAMDamBreakBase(OpenFOAMBase):
     """OpenFOAM DamBreak test base class"""
 
     num_tasks_per_node = 1
-    num_cpus_per_task = 128
     time_limit = "10m"
-    freq = parameter(["2250000", "2000000"])
+
+   
 
     @run_after("init")
     def setup_params(self):
         """sets up extra parameters"""
+
+        if self.current_system.name in ["archer2"]:
+            freq = parameter(["2250000", "2000000"])
         if self.current_system.name in ["archer2"]:
             self.env_vars = {
                 "OMP_NUM_THREADS": str(self.num_cpus_per_task),
                 "OMP_PLACES": "cores",
                 "SLURM_CPU_FREQ_REQ": self.freq,
             }
+
+    @run_before("run")
+    def set_num_tasks(self):
+        """Sets number of tasks"""
+        if self.current_system.name in ["archer2"]:
+            self.num_cpus_per_task = 128
+            self.num_tasks_per_node = 1
+            self.num_tasks = self.num_tasks_per_node * self.num_nodes
+        elif self.current_system.name in ["cirrus-ex"]:
+            self.num_cpus_per_task = 288
+            self.num_tasks_per_node = 1
+            self.num_tasks = self.num_tasks_per_node * self.num_nodes
 
     @run_before("run")
     def setup_testcase(self):
@@ -44,22 +59,27 @@ class OpenFOAMDamBreakBase(OpenFOAMBase):
         """Changes reference values"""
         if self.current_system.name in ["archer2"]:
             # https://reframe-hpc.readthedocs.io/en/stable/utility_functions_reference.html#reframe.utility.ScopedDict
-            self.reference["archer2:compute:performance"] = self.reference_performance[self.freq]
-
+            self.reference["archer2:compute:performance"] = self.reference_performance_archer2[self.freq]
+        
+        elif self.current_system.name in ["cirrus-ex"]:
+            self.reference["cirrus-ex:compute:performance"] = self.reference_performance_cirrus_ex
+        
 
 class OpenFOAMDamBreakOneNode(OpenFOAMDamBreakBase):
     """OpenFOAM DamBreak base test on 1 node"""
 
     executable = "interFoam"
     executable_opts = ("").split()
-    modules = [f"openfoam/org/v{OpenFOAMBase.version}"]
 
     num_tasks = 1
+    num_nodes = 1
 
-    reference_performance = {
+    reference_performance_archer2 = {
         "2000000": (6, -0.1, 0.1, "seconds"),
         "2250000": (3.6, -0.1, 0.1, "seconds"),
     }
+
+    reference_performance_cirrus_ex = (5, -0.5, 0.5, "seconds")
 
 
 @rfm.simple_test
@@ -67,8 +87,14 @@ class OpenFOAMDamBreakOneNodeModule(OpenFOAMDamBreakOneNode):
     """OpenFOAM DamBreak test on 1 node with module"""
 
     executable = "interFoam"
-    modules = [f"openfoam/org/v{OpenFOAMBase.version}"]
 
+    @run_before("run")
+    def load_modules(self):
+        if self.current_system.name in ["archer2"]:
+            self.modules = [f"openfoam/org/v{OpenFOAMBase.version}"]
+        elif self.current_system.name in ["cirrus-ex"]:
+            self.modules = [f"openfoam-org"]
+    
 
 @rfm.simple_test
 class OpenFOAMDamBreakOneNodeBuild(OpenFOAMDamBreakOneNode):
@@ -98,10 +124,12 @@ class OpenFOAMDamBreakParallel(OpenFOAMDamBreakBase):
     num_tasks = 4
     executable_opts = ("-parallel").split()
 
-    reference_performance = {
+    reference_performance_archer2 = {
         "2000000": (5, -0.5, 0.5, "seconds"),
         "2250000": (5, -0.5, 0.5, "seconds"),
     }
+
+    reference_performance_cirrus_ex = (5, -0.5, 0.5, "seconds")    
 
     @run_before("run")
     def setup_testcase(self):
@@ -118,9 +146,15 @@ class OpenFOAMDamBreakParallel(OpenFOAMDamBreakBase):
 @rfm.simple_test
 class OpenFOAMDamBreakParallelModule(OpenFOAMDamBreakParallel):
     """OpenFOAM DamBreak test on 4 nodes with module"""
-
+    
     executable = "interFoam"
-    modules = [f"openfoam/org/v{OpenFOAMBase.version}"]
+    @run_before("run")
+    def load_modules(self): 
+        if  self.current_system.name in ["archer2"]:
+            modules = [f"openfoam/org/v{OpenFOAMBase.version}"]
+        elif self.current_system.name in ["cirrus-ex"]:
+            modules = [f"openfoam-org"]
+    
 
 
 @rfm.simple_test

--- a/tests/apps/openfoam/openfoam_org_dambreak.py
+++ b/tests/apps/openfoam/openfoam_org_dambreak.py
@@ -8,11 +8,13 @@ from openfoam_org_base import OpenFOAMBase
 from openfoam_org_build import CompileOpenFOAM
 
 
+
 class OpenFOAMDamBreakBase(OpenFOAMBase):
     """OpenFOAM DamBreak test base class"""
 
     num_tasks_per_node = 1
     time_limit = "10m"
+    valid_systems = ["archer2:compute"]
 
    
 
@@ -28,6 +30,12 @@ class OpenFOAMDamBreakBase(OpenFOAMBase):
                 "OMP_PLACES": "cores",
                 "SLURM_CPU_FREQ_REQ": self.freq,
             }
+        
+        if self.current_system.name in ["cirrus-ex"]:
+            self.env_vars.update(
+            {"FOAM_INSTALL_DIR": "$FOAM_ETC/.."}
+                                 )
+            
 
     @run_before("run")
     def set_num_tasks(self):
@@ -44,9 +52,19 @@ class OpenFOAMDamBreakBase(OpenFOAMBase):
     @run_before("run")
     def setup_testcase(self):
         """set up test case"""
+
+        if (self.v_major == "10"):
+            tutorial_sub_dir="tutorials/multiphase/interFoam/laminar/damBreak/damBreak"
+        else:
+            if (self.v_major == "12"):
+                tutorial_sub_dir="tutorials/incompressibleVoF/damBreak"
+            else:
+                raise ValueError("Unsupported OpenFOAM version")        
+        
+        
         self.prerun_cmds = [
             "source ${FOAM_INSTALL_DIR}/etc/bashrc",
-            "cp -r ${FOAM_INSTALL_DIR}/tutorials/multiphase/interFoam/laminar/damBreak/damBreak .",
+            f"cp -r $FOAM_INSTALL_DIR/{tutorial_sub_dir} .",
             "cd damBreak",
             "blockMesh",
             "cp 0/alpha.water.orig 0/alpha.water",
@@ -71,6 +89,7 @@ class OpenFOAMDamBreakOneNode(OpenFOAMDamBreakBase):
     executable = "interFoam"
     executable_opts = ("").split()
 
+
     num_tasks = 1
     num_nodes = 1
 
@@ -79,12 +98,13 @@ class OpenFOAMDamBreakOneNode(OpenFOAMDamBreakBase):
         "2250000": (3.6, -0.1, 0.1, "seconds"),
     }
 
-    reference_performance_cirrus_ex = (5, -0.5, 0.5, "seconds")
+    reference_performance_cirrus_ex = (3, -0.5, 0.5, "seconds")
 
 
 @rfm.simple_test
 class OpenFOAMDamBreakOneNodeModule(OpenFOAMDamBreakOneNode):
     """OpenFOAM DamBreak test on 1 node with module"""
+    valid_systems = ["archer2:compute","cirrus-ex:compute"]
 
     executable = "interFoam"
 
@@ -121,7 +141,7 @@ class OpenFOAMDamBreakOneNodeBuild(OpenFOAMDamBreakOneNode):
 class OpenFOAMDamBreakParallel(OpenFOAMDamBreakBase):
     """OpenFOAM DamBreak base test on 4 nodes"""
 
-    num_tasks = 4
+    num_nodes = 4
     executable_opts = ("-parallel").split()
 
     reference_performance_archer2 = {
@@ -135,7 +155,9 @@ class OpenFOAMDamBreakParallel(OpenFOAMDamBreakBase):
     def setup_testcase(self):
         """Set up test case"""
         super().setup_testcase()
-        self.prerun_cmds = [*self.prerun_cmds, "decomposePar"]
+        self.prerun_cmds = [*self.prerun_cmds, 
+            "cp -r ../decomposeParDict system",
+        "decomposePar"]
 
     @sanity_function
     def assert_finished_parallel(self):
@@ -147,13 +169,15 @@ class OpenFOAMDamBreakParallel(OpenFOAMDamBreakBase):
 class OpenFOAMDamBreakParallelModule(OpenFOAMDamBreakParallel):
     """OpenFOAM DamBreak test on 4 nodes with module"""
     
+    valid_systems = ["archer2:compute","cirrus-ex:compute"]
+    
     executable = "interFoam"
     @run_before("run")
     def load_modules(self): 
         if  self.current_system.name in ["archer2"]:
-            modules = [f"openfoam/org/v{OpenFOAMBase.version}"]
+            self.modules = [f"openfoam/org/v{OpenFOAMBase.version}"]
         elif self.current_system.name in ["cirrus-ex"]:
-            modules = [f"openfoam-org"]
+            self.modules = [f"openfoam-org"]
     
 
 

--- a/tests/apps/openfoam/openfoam_org_dambreak.py
+++ b/tests/apps/openfoam/openfoam_org_dambreak.py
@@ -15,12 +15,13 @@ class OpenFOAMDamBreakBase(OpenFOAMBase):
     num_tasks_per_node = 1
     time_limit = "10m"
     valid_systems = ["archer2:compute"]
-
-   
-
+    
     @run_after("init")
     def setup_params(self):
         """sets up extra parameters"""
+
+       
+
 
         if self.current_system.name in ["archer2"]:
             freq = parameter(["2250000", "2000000"])
@@ -53,13 +54,13 @@ class OpenFOAMDamBreakBase(OpenFOAMBase):
     def setup_testcase(self):
         """set up test case"""
 
-        if (self.v_major == "10"):
+        if (self.version.startswith("10")):
             tutorial_sub_dir="tutorials/multiphase/interFoam/laminar/damBreak/damBreak"
         else:
-            if (self.v_major == "12"):
+            if (self.version.startswith("12")):
                 tutorial_sub_dir="tutorials/incompressibleVoF/damBreak"
             else:
-                raise ValueError("Unsupported OpenFOAM version")        
+                raise ValueError("Unsupported OpenFOAM version")
         
         
         self.prerun_cmds = [
@@ -88,8 +89,8 @@ class OpenFOAMDamBreakOneNode(OpenFOAMDamBreakBase):
 
     executable = "interFoam"
     executable_opts = ("").split()
-
-
+    valid_systems = ["archer2:compute","cirrus-ex:compute"]
+    
     num_tasks = 1
     num_nodes = 1
 
@@ -170,6 +171,7 @@ class OpenFOAMDamBreakParallelModule(OpenFOAMDamBreakParallel):
     """OpenFOAM DamBreak test on 4 nodes with module"""
     
     valid_systems = ["archer2:compute","cirrus-ex:compute"]
+
     
     executable = "interFoam"
     @run_before("run")

--- a/tests/apps/openfoam/openfoam_org_dambreak.py
+++ b/tests/apps/openfoam/openfoam_org_dambreak.py
@@ -89,7 +89,7 @@ class OpenFOAMDamBreakOneNode(OpenFOAMDamBreakBase):
 
     executable = "interFoam"
     executable_opts = ("").split()
-    valid_systems = ["archer2:compute","cirrus-ex:compute"]
+    valid_systems = ["archer2:compute"]
     
     num_tasks = 1
     num_nodes = 1

--- a/tests/apps/openfoam/openfoam_org_dambreak.py
+++ b/tests/apps/openfoam/openfoam_org_dambreak.py
@@ -122,7 +122,7 @@ class OpenFOAMDamBreakOneNodeModule(OpenFOAMDamBreakOneNode):
         if self.current_system.name in ["archer2"]:
             self.modules = [f"openfoam/org/v{self.version}"]
         elif self.current_system.name in ["cirrus-ex"]:
-            self.modules = [f"openfoam-org"]
+            self.modules = ["openfoam-org"]
 
 
 @rfm.simple_test
@@ -185,7 +185,7 @@ class OpenFOAMDamBreakParallelModule(OpenFOAMDamBreakParallel):
         if self.current_system.name in ["archer2"]:
             self.modules = [f"openfoam/org/v{self.version}"]
         elif self.current_system.name in ["cirrus-ex"]:
-            self.modules = [f"openfoam-org"]
+            self.modules = ["openfoam-org"]
 
 
 @rfm.simple_test

--- a/tests/apps/openfoam/openfoam_org_dambreak.py
+++ b/tests/apps/openfoam/openfoam_org_dambreak.py
@@ -119,6 +119,7 @@ class OpenFOAMDamBreakOneNodeModule(OpenFOAMDamBreakOneNode):
 
     @run_before("run")
     def load_modules(self):
+        "Loads modules based on current system"
         if self.current_system.name in ["archer2"]:
             self.modules = [f"openfoam/org/v{self.version}"]
         elif self.current_system.name in ["cirrus-ex"]:

--- a/tests/apps/openfoam/openfoam_org_dambreak.py
+++ b/tests/apps/openfoam/openfoam_org_dambreak.py
@@ -8,23 +8,34 @@ from openfoam_org_base import OpenFOAMBase
 from openfoam_org_build import CompileOpenFOAM
 
 
-
 class OpenFOAMDamBreakBase(OpenFOAMBase):
     """OpenFOAM DamBreak test base class"""
 
     num_tasks_per_node = 1
     time_limit = "10m"
     valid_systems = ["archer2:compute"]
+
+    freq = parameter(["2250000", "2000000"])
+
+    @sanity_function
+    def assert_finished(self):
+        """Sanity check that simulation finished successfully"""
+        return sn.assert_found("End", self.stdout)
+
+    @performance_function("seconds", perf_key="performance")
+    def extract_perf(self):
+        """Extract performance value to compare with reference value"""
+        return sn.extractsingle(
+            r"ExecutionTime\s+=\s+(?P<time>\d+.?\d*\s+)s\s+ClockTime\s+=\s+\d*\s+s\n\nEnd",
+            self.stdout,
+            "time",
+            float,
+        )
     
     @run_after("init")
     def setup_params(self):
         """sets up extra parameters"""
-
        
-
-
-        if self.current_system.name in ["archer2"]:
-            freq = parameter(["2250000", "2000000"])
         if self.current_system.name in ["archer2"]:
             self.env_vars = {
                 "OMP_NUM_THREADS": str(self.num_cpus_per_task),
@@ -112,7 +123,7 @@ class OpenFOAMDamBreakOneNodeModule(OpenFOAMDamBreakOneNode):
     @run_before("run")
     def load_modules(self):
         if self.current_system.name in ["archer2"]:
-            self.modules = [f"openfoam/org/v{OpenFOAMBase.version}"]
+            self.modules = [f"openfoam/org/v{self.version}"]
         elif self.current_system.name in ["cirrus-ex"]:
             self.modules = [f"openfoam-org"]
     
@@ -128,14 +139,14 @@ class OpenFOAMDamBreakOneNodeBuild(OpenFOAMDamBreakOneNode):
         """sets up extra parameters"""
         super().setup_params()
         self.env_vars.update(
-            {"FOAM_INSTALL_DIR": os.path.join(self.interfoam_binary.stagedir, f"OpenFOAM-{OpenFOAMBase.v_major}")}
+            {"FOAM_INSTALL_DIR": os.path.join(self.interfoam_binary.stagedir, f"OpenFOAM-{self.v_major}")}
         )
 
     @run_after("setup")
     def set_executable(self):
         """Sets up executable"""
         self.executable = os.path.join(
-            self.interfoam_binary.stagedir, f"OpenFOAM-{OpenFOAMBase.v_major}/platforms/crayGccDPInt32Opt/bin/interFoam"
+            self.interfoam_binary.stagedir, f"OpenFOAM-{self.v_major}/platforms/crayGccDPInt32Opt/bin/interFoam"
         )
 
 
@@ -177,7 +188,7 @@ class OpenFOAMDamBreakParallelModule(OpenFOAMDamBreakParallel):
     @run_before("run")
     def load_modules(self): 
         if  self.current_system.name in ["archer2"]:
-            self.modules = [f"openfoam/org/v{OpenFOAMBase.version}"]
+            self.modules = [f"openfoam/org/v{self.version}"]
         elif self.current_system.name in ["cirrus-ex"]:
             self.modules = [f"openfoam-org"]
     
@@ -188,18 +199,18 @@ class OpenFOAMDamBreakParallelBuild(OpenFOAMDamBreakParallel):
     """OpenFOAM DamBreak test on 4 nodes with reframe source build"""
 
     interfoam_binary = fixture(CompileOpenFOAM, scope="environment")
-
+    
     @run_after("setup")
     def setup_extra_params(self):
         """sets up extra parameters"""
         super().setup_params()
         self.env_vars.update(
-            {"FOAM_INSTALL_DIR": os.path.join(self.interfoam_binary.stagedir, f"OpenFOAM-{OpenFOAMBase.v_major}")}
+            {"FOAM_INSTALL_DIR": os.path.join(self.interfoam_binary.stagedir, f"OpenFOAM-{self.v_major}")}
         )
 
     @run_after("setup")
     def set_executable(self):
         """Sets up executable"""
         self.executable = os.path.join(
-            self.interfoam_binary.stagedir, f"OpenFOAM-{OpenFOAMBase.v_major}/platforms/crayGccDPInt32Opt/bin/interFoam"
+            self.interfoam_binary.stagedir, f"OpenFOAM-{self.v_major}/platforms/crayGccDPInt32Opt/bin/interFoam"
         )

--- a/tests/apps/openfoam/openfoam_org_dambreak.py
+++ b/tests/apps/openfoam/openfoam_org_dambreak.py
@@ -31,23 +31,20 @@ class OpenFOAMDamBreakBase(OpenFOAMBase):
             "time",
             float,
         )
-    
+
     @run_after("init")
     def setup_params(self):
         """sets up extra parameters"""
-       
+
         if self.current_system.name in ["archer2"]:
             self.env_vars = {
                 "OMP_NUM_THREADS": str(self.num_cpus_per_task),
                 "OMP_PLACES": "cores",
                 "SLURM_CPU_FREQ_REQ": self.freq,
             }
-        
+
         if self.current_system.name in ["cirrus-ex"]:
-            self.env_vars.update(
-            {"FOAM_INSTALL_DIR": "$FOAM_ETC/.."}
-                                 )
-            
+            self.env_vars.update({"FOAM_INSTALL_DIR": "$FOAM_ETC/.."})
 
     @run_before("run")
     def set_num_tasks(self):
@@ -65,15 +62,14 @@ class OpenFOAMDamBreakBase(OpenFOAMBase):
     def setup_testcase(self):
         """set up test case"""
 
-        if (self.version.startswith("10")):
-            tutorial_sub_dir="tutorials/multiphase/interFoam/laminar/damBreak/damBreak"
+        if self.version.startswith("10"):
+            tutorial_sub_dir = "tutorials/multiphase/interFoam/laminar/damBreak/damBreak"
         else:
-            if (self.version.startswith("12")):
-                tutorial_sub_dir="tutorials/incompressibleVoF/damBreak"
+            if self.version.startswith("12"):
+                tutorial_sub_dir = "tutorials/incompressibleVoF/damBreak"
             else:
                 raise ValueError("Unsupported OpenFOAM version")
-        
-        
+
         self.prerun_cmds = [
             "source ${FOAM_INSTALL_DIR}/etc/bashrc",
             f"cp -r $FOAM_INSTALL_DIR/{tutorial_sub_dir} .",
@@ -90,10 +86,10 @@ class OpenFOAMDamBreakBase(OpenFOAMBase):
         if self.current_system.name in ["archer2"]:
             # https://reframe-hpc.readthedocs.io/en/stable/utility_functions_reference.html#reframe.utility.ScopedDict
             self.reference["archer2:compute:performance"] = self.reference_performance_archer2[self.freq]
-        
+
         elif self.current_system.name in ["cirrus-ex"]:
             self.reference["cirrus-ex:compute:performance"] = self.reference_performance_cirrus_ex
-        
+
 
 class OpenFOAMDamBreakOneNode(OpenFOAMDamBreakBase):
     """OpenFOAM DamBreak base test on 1 node"""
@@ -101,7 +97,7 @@ class OpenFOAMDamBreakOneNode(OpenFOAMDamBreakBase):
     executable = "interFoam"
     executable_opts = ("").split()
     valid_systems = ["archer2:compute"]
-    
+
     num_tasks = 1
     num_nodes = 1
 
@@ -116,7 +112,8 @@ class OpenFOAMDamBreakOneNode(OpenFOAMDamBreakBase):
 @rfm.simple_test
 class OpenFOAMDamBreakOneNodeModule(OpenFOAMDamBreakOneNode):
     """OpenFOAM DamBreak test on 1 node with module"""
-    valid_systems = ["archer2:compute","cirrus-ex:compute"]
+
+    valid_systems = ["archer2:compute", "cirrus-ex:compute"]
 
     executable = "interFoam"
 
@@ -126,7 +123,7 @@ class OpenFOAMDamBreakOneNodeModule(OpenFOAMDamBreakOneNode):
             self.modules = [f"openfoam/org/v{self.version}"]
         elif self.current_system.name in ["cirrus-ex"]:
             self.modules = [f"openfoam-org"]
-    
+
 
 @rfm.simple_test
 class OpenFOAMDamBreakOneNodeBuild(OpenFOAMDamBreakOneNode):
@@ -138,9 +135,7 @@ class OpenFOAMDamBreakOneNodeBuild(OpenFOAMDamBreakOneNode):
     def setup_extra_params(self):
         """sets up extra parameters"""
         super().setup_params()
-        self.env_vars.update(
-            {"FOAM_INSTALL_DIR": os.path.join(self.interfoam_binary.stagedir, f"OpenFOAM-{self.v_major}")}
-        )
+        self.env_vars.update({"FOAM_INSTALL_DIR": os.path.join(self.interfoam_binary.stagedir, f"OpenFOAM-{self.v_major}")})
 
     @run_after("setup")
     def set_executable(self):
@@ -161,15 +156,13 @@ class OpenFOAMDamBreakParallel(OpenFOAMDamBreakBase):
         "2250000": (5, -0.5, 0.5, "seconds"),
     }
 
-    reference_performance_cirrus_ex = (5, -0.5, 0.5, "seconds")    
+    reference_performance_cirrus_ex = (5, -0.5, 0.5, "seconds")
 
     @run_before("run")
     def setup_testcase(self):
         """Set up test case"""
         super().setup_testcase()
-        self.prerun_cmds = [*self.prerun_cmds, 
-            "cp -r ../decomposeParDict system",
-        "decomposePar"]
+        self.prerun_cmds = [*self.prerun_cmds, "cp -r ../decomposeParDict system", "decomposePar"]
 
     @sanity_function
     def assert_finished_parallel(self):
@@ -180,18 +173,17 @@ class OpenFOAMDamBreakParallel(OpenFOAMDamBreakBase):
 @rfm.simple_test
 class OpenFOAMDamBreakParallelModule(OpenFOAMDamBreakParallel):
     """OpenFOAM DamBreak test on 4 nodes with module"""
-    
-    valid_systems = ["archer2:compute","cirrus-ex:compute"]
 
-    
+    valid_systems = ["archer2:compute", "cirrus-ex:compute"]
+
     executable = "interFoam"
+
     @run_before("run")
-    def load_modules(self): 
-        if  self.current_system.name in ["archer2"]:
+    def load_modules(self):
+        if self.current_system.name in ["archer2"]:
             self.modules = [f"openfoam/org/v{self.version}"]
         elif self.current_system.name in ["cirrus-ex"]:
             self.modules = [f"openfoam-org"]
-    
 
 
 @rfm.simple_test
@@ -199,14 +191,12 @@ class OpenFOAMDamBreakParallelBuild(OpenFOAMDamBreakParallel):
     """OpenFOAM DamBreak test on 4 nodes with reframe source build"""
 
     interfoam_binary = fixture(CompileOpenFOAM, scope="environment")
-    
+
     @run_after("setup")
     def setup_extra_params(self):
         """sets up extra parameters"""
         super().setup_params()
-        self.env_vars.update(
-            {"FOAM_INSTALL_DIR": os.path.join(self.interfoam_binary.stagedir, f"OpenFOAM-{self.v_major}")}
-        )
+        self.env_vars.update({"FOAM_INSTALL_DIR": os.path.join(self.interfoam_binary.stagedir, f"OpenFOAM-{self.v_major}")})
 
     @run_after("setup")
     def set_executable(self):

--- a/tests/apps/openfoam/src/decomposeParDict
+++ b/tests/apps/openfoam/src/decomposeParDict
@@ -1,0 +1,42 @@
+/*--------------------------------*- C++ -*----------------------------------*\
+  =========                 |
+  \\      /  F ield         | OpenFOAM: The Open Source CFD Toolbox
+   \\    /   O peration     | Website:  https://openfoam.org
+    \\  /    A nd           | Version:  10
+     \\/     M anipulation  |
+\*---------------------------------------------------------------------------*/
+FoamFile
+{
+    format      ascii;
+    class       dictionary;
+    location    "system";
+    object      decomposeParDict;
+}
+// * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * //
+
+numberOfSubdomains 4;
+
+method          simple;
+
+simpleCoeffs
+{
+    n               (2 2 1);
+}
+
+hierarchicalCoeffs
+{
+    n               (1 1 1);
+    order           xyz;
+}
+
+manualCoeffs
+{
+    dataFile        "";
+}
+
+distributed     no;
+
+roots           ( );
+
+
+// ************************************************************************* //

--- a/tests/libs/pytorch/deepcam.py
+++ b/tests/libs/pytorch/deepcam.py
@@ -44,7 +44,7 @@ class DeepCAMGPUtest(DeepCAMBase):
                 "qos": {"qos": "gpu"},
                 "gpu": {"num_gpus_per_node": str(self.num_gpus)},
             }
-        
+
         self.executable_opts = [
             train_script,
             "--wireup_method nccl-slurm",
@@ -78,18 +78,19 @@ class DeepCAMGPUtest(DeepCAMBase):
 @rfm.simple_test
 class DeepCAMCPUtest(DeepCAMBase):
     """Running DeepCAM on CPU"""
-    
+
     num_nodes = 4
     num_tasks_per_node = 8
     num_cpus_per_task = 16
     num_tasks = 32
     time_limit = "1h"
-    valid_systems = ["archer2:compute","cirrus-ex:compute"]
+    valid_systems = ["archer2:compute", "cirrus-ex:compute"]
 
     valid_prog_environs = ["PrgEnv-cray"]
-    reference = {"archer2:compute": {"epoch-time": (272, -0.1, 0.1, "s")}
-                 ,"cirrus-ex:compute": {"epoch-time": (40.08, -0.01, 0.01, "s")}
-                 }
+    reference = {
+        "archer2:compute": {"epoch-time": (272, -0.1, 0.1, "s")},
+        "cirrus-ex:compute": {"epoch-time": (40.08, -0.01, 0.01, "s")},
+    }
 
     @run_after("init")
     def set_modules(self):
@@ -102,13 +103,13 @@ class DeepCAMCPUtest(DeepCAMBase):
         if self.current_system.name in ["cirrus-ex"]:
             self.num_tasks_per_node = 24
             self.num_cpus_per_task = 12
-        
+
         if self.current_system.name in ["archer2"]:
             self.num_tasks_per_node = 8
             self.num_cpus_per_task = 16
-        
+
         self.num_tasks = self.num_nodes * self.num_tasks_per_node
-        
+
     @run_after("setup")
     def setup_job(self):
         """Set-up submission script"""
@@ -119,7 +120,7 @@ class DeepCAMCPUtest(DeepCAMBase):
             data_dir_prefix = "/work/z04/shared/mlperf-hpc/deepcam/mini/"
         if self.current_system.name in ["archer2"]:
             data_dir_prefix = "/work/z19/shared/mlperf-hpc/deepcam/mini/"
-        
+
         self.executable_opts = [
             train_script,
             "--wireup_method mpi",

--- a/tests/libs/pytorch/deepcam.py
+++ b/tests/libs/pytorch/deepcam.py
@@ -94,11 +94,13 @@ class DeepCAMCPUtest(DeepCAMBase):
 
     @run_after("init")
     def set_modules(self):
+        "Defined modules to load based on current system"
         if self.current_system.name in ["cirrus-ex"]:
             self.modules = ["py-torch"]
 
     @run_after("init")
     def set_num_tasks(self):
+        "Set number of tasks based on current system"
 
         if self.current_system.name in ["cirrus-ex"]:
             self.num_tasks_per_node = 24

--- a/tests/libs/pytorch/deepcam.py
+++ b/tests/libs/pytorch/deepcam.py
@@ -38,7 +38,7 @@ class DeepCAMGPUtest(DeepCAMBase):
             }
         elif part == "cirrus:compute-gpu":
             self.modules = ["nvidia/cudnn/8.6.0-cuda-11.6"]
-            data_dir_prefix = "/work/z04/shared/mlperf-hpc/deepcam/mini/"
+            data_dir_prefix = "/work/z19/shared/mlperf-hpc/deepcam/mini/"
             local_batch_size = 1
             self.extra_resources = {
                 "qos": {"qos": "gpu"},
@@ -119,7 +119,7 @@ class DeepCAMCPUtest(DeepCAMBase):
 
         data_dir_prefix = None
         if self.current_system.name in ["cirrus-ex"]:
-            data_dir_prefix = "/work/z04/shared/mlperf-hpc/deepcam/mini/"
+            data_dir_prefix = "/work/z19/shared/mlperf-hpc/deepcam/mini/"
         if self.current_system.name in ["archer2"]:
             data_dir_prefix = "/work/z19/shared/mlperf-hpc/deepcam/mini/"
 

--- a/tests/libs/pytorch/deepcam.py
+++ b/tests/libs/pytorch/deepcam.py
@@ -85,9 +85,10 @@ class DeepCAMCPUtest(DeepCAMBase):
     num_tasks = 32
     time_limit = "1h"
     valid_systems = ["archer2:compute","cirrus-ex:compute"]
+
     valid_prog_environs = ["PrgEnv-cray"]
     reference = {"archer2:compute": {"epoch-time": (272, -0.1, 0.1, "s")}
-                 ,"cirrus-ex:compute": {"epoch-time": (119.7, -0.01, 0.01, "s")}
+                 ,"cirrus-ex:compute": {"epoch-time": (40.08, -0.01, 0.01, "s")}
                  }
 
     @run_after("init")

--- a/tests/libs/pytorch/deepcam.py
+++ b/tests/libs/pytorch/deepcam.py
@@ -44,6 +44,7 @@ class DeepCAMGPUtest(DeepCAMBase):
                 "qos": {"qos": "gpu"},
                 "gpu": {"num_gpus_per_node": str(self.num_gpus)},
             }
+        
         self.executable_opts = [
             train_script,
             "--wireup_method nccl-slurm",
@@ -77,32 +78,59 @@ class DeepCAMGPUtest(DeepCAMBase):
 @rfm.simple_test
 class DeepCAMCPUtest(DeepCAMBase):
     """Running DeepCAM on CPU"""
-
+    
     num_nodes = 4
     num_tasks_per_node = 8
     num_cpus_per_task = 16
     num_tasks = 32
     time_limit = "1h"
-    valid_systems = ["archer2:compute"]
+    valid_systems = ["archer2:compute","cirrus-ex:compute"]
     valid_prog_environs = ["PrgEnv-cray"]
-    extra_resources = {"qos": {"qos": "standard"}}
-    reference = {"archer2:compute": {"epoch-time": (272, -0.1, 0.1, "s")}}
+    reference = {"archer2:compute": {"epoch-time": (272, -0.1, 0.1, "s")}
+                 ,"cirrus-ex:compute": {"epoch-time": (119.7, -0.01, 0.01, "s")}
+                 }
 
+    @run_after("init")
+    def set_modules(self):
+        if self.current_system.name in ["cirrus-ex"]:
+            self.modules = ["py-torch"]
+
+    @run_after("init")
+    def set_num_tasks(self):
+
+        if self.current_system.name in ["cirrus-ex"]:
+            self.num_tasks_per_node = 24
+            self.num_cpus_per_task = 12
+        
+        if self.current_system.name in ["archer2"]:
+            self.num_tasks_per_node = 8
+            self.num_cpus_per_task = 16
+        
+        self.num_tasks = self.num_nodes * self.num_tasks_per_node
+        
     @run_after("setup")
     def setup_job(self):
         """Set-up submission script"""
         train_script = os.path.join(self.mlperf_benchmarks.stagedir, "hpc", "deepcam", "src", "deepCam", "train.py")
+
+        data_dir_prefix = None
+        if self.current_system.name in ["cirrus-ex"]:
+            data_dir_prefix = "/work/z04/shared/mlperf-hpc/deepcam/mini/"
+        if self.current_system.name in ["archer2"]:
+            data_dir_prefix = "/work/z19/shared/mlperf-hpc/deepcam/mini/"
+        
         self.executable_opts = [
             train_script,
             "--wireup_method mpi",
             "--run_tag reframe-cpu",
             "--output_dir ${JOB_OUTPUT_PATH}",
-            "--data_dir_prefix /work/z19/shared/mlperf-hpc/deepcam/mini",
+            f"--data_dir_prefix {data_dir_prefix}",
             "--local_batch_size 1",
             "--max_inter_threads ${SLURM_CPUS_PER_TASK}",
             "--max_epochs 5",
             "--seed ${SLURM_JOB_ID}",
         ]
+
         self.env_vars = {
             "OMP_NUM_THREADS": "${SLURM_CPUS_PER_TASK}",
             "HOME": "${HOME/home/work}",

--- a/tests/libs/pytorch/mlperf_build.py
+++ b/tests/libs/pytorch/mlperf_build.py
@@ -45,11 +45,17 @@ class BuildMLPerfPytorchEnv(rfm.CompileOnlyRegressionTest):
         if part in ("archer2:compute-gpu", "cirrus:compute-gpu"):
             self.modules = ["pytorch/1.13.1-gpu"]
             self.env_vars["PYVENV_NAME"] = "reframe-mlperf-gpu"
+            build_script = "build_pytorch_env.sh"
         elif part == "archer2:compute":
             self.modules = ["pytorch/1.13.0a0"]
             self.env_vars["PYVENV_NAME"] = "reframe-mlperf-cpu"
+        elif part == "cirrus-ex:compute":
+            self.modules = ["py-torch"]
+            self.env_vars["PYVENV_NAME"] = "reframe-mlperf-cpu"
+            build_script = "build_pytorch_cirrus_ex_env.sh"
+        
 
-        self.build_system.commands = ["chmod u+x build_pytorch_env.sh", "./build_pytorch_env.sh"]
+        self.build_system.commands = [f"chmod u+x {build_script}", f"./{build_script}"]
 
     @sanity_function
     def sanity_check_build(self):

--- a/tests/libs/pytorch/mlperf_build.py
+++ b/tests/libs/pytorch/mlperf_build.py
@@ -42,6 +42,8 @@ class BuildMLPerfPytorchEnv(rfm.CompileOnlyRegressionTest):
     def prepare_env(self):
         """Load the correct modules and name env"""
         part = self.current_partition.fullname
+        build_script = None
+
         if part in ("archer2:compute-gpu", "cirrus:compute-gpu"):
             self.modules = ["pytorch/1.13.1-gpu"]
             self.env_vars["PYVENV_NAME"] = "reframe-mlperf-gpu"

--- a/tests/libs/pytorch/mlperf_build.py
+++ b/tests/libs/pytorch/mlperf_build.py
@@ -49,6 +49,7 @@ class BuildMLPerfPytorchEnv(rfm.CompileOnlyRegressionTest):
         elif part == "archer2:compute":
             self.modules = ["pytorch/1.13.0a0"]
             self.env_vars["PYVENV_NAME"] = "reframe-mlperf-cpu"
+            build_script = "build_pytorch_env.sh"
         elif part == "cirrus-ex:compute":
             self.modules = ["py-torch"]
             self.env_vars["PYVENV_NAME"] = "reframe-mlperf-cpu"

--- a/tests/libs/pytorch/mlperf_build.py
+++ b/tests/libs/pytorch/mlperf_build.py
@@ -54,7 +54,6 @@ class BuildMLPerfPytorchEnv(rfm.CompileOnlyRegressionTest):
             self.modules = ["py-torch"]
             self.env_vars["PYVENV_NAME"] = "reframe-mlperf-cpu"
             build_script = "build_pytorch_cirrus_ex_env.sh"
-        
 
         self.build_system.commands = [f"chmod u+x {build_script}", f"./{build_script}"]
 

--- a/tests/libs/pytorch/src/build_pytorch_cirrus_ex_env.sh
+++ b/tests/libs/pytorch/src/build_pytorch_cirrus_ex_env.sh
@@ -1,0 +1,30 @@
+#!/bin/bash 
+
+PYTHON_TAG=python`echo ${CRAY_PYTHON_LEVEL} | cut -d. -f1-2`
+
+# PRFX=${HOME/home/work}/pyenvs
+# PYVENV_ROOT=${PRFX}/${PYVENV_NAME}
+# PYVENV_SITEPKGS=${PYVENV_ROOT}/lib/${PYTHON_TAG}/site-packages
+
+echo ${PYVENV_NAME}
+
+mkdir -p ${PYVENV_NAME}
+cd ${PYVENV_NAME}
+
+python -m venv --system-site-packages ${PYVENV_NAME}
+extend-venv-activate ${PYVENV_NAME}
+source ${PYVENV_NAME}/bin/activate
+
+mkdir -p ${PYVENV_NAME}/repos
+cd ${PYVENV_NAME}/repos
+
+## Install mlperf loging package
+wget https://github.com/mlcommons/logging/archive/refs/tags/5.1.0-rc4.tar.gz
+tar -zxvf 5.1.0-rc4.tar.gz
+python -m pip install -e logging-5.1.0-rc4
+
+python -m pip install git+https://github.com/ildoonet/pytorch-gradual-warmup-lr.git
+
+python -m pip install h5py
+
+deactivate


### PR DESCRIPTION
This adds application tests for cirrus-ex ( see #105 ) . Not all lammps tests have been ported over.
This required changing some of the tests we run on Archer2, so that we test more apps from the module system instead of  reframe builds. Some refacting was also needed.

 - Tested with reframe version 4.8.2 . Tested on archer2 with 
```
module use /mnt/lustre/a2fs-work4/work/y07/shared/archer2-lmod/utils/dev
module load reframe/4.8.2
module load cray-python
EPCC_REFRAME_ROOT=../epcc-reframe

reframe  -C $EPCC_REFRAME_ROOT/configuration/archer2.py -R  --keep-stage-files --performance-report -c $EPCC_REFRAME_ROOT/tests -T largescale -n LAMMPS -n OpenFOAM -n CASTEP -n DeepCAMCPU -n CP2K --report-file report.json
```

- cp2k does not work on Archer2, due to an issue with the centrally installed module ( see  #86  ) . This is a pre-exisiting issue.
- cp2k regression tests for cirrus-ex was added, but not Archer2, due to issues with the cp2k module. This is not a test suitable for performance. ( see #104 )
- openfom was adapted so that it can work with two different versions ( 10 on Archer2 , as per the original test,  and 12 on cirrus-ex ). We only compile on A2, as compilation can be tested trough spack on cirrus-ex , so testing compilation in Reframe is superflous.